### PR TITLE
adding export to pass on variable to child shell

### DIFF
--- a/run-integration-tests.sh
+++ b/run-integration-tests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-ZABBIX_API_URL=http://localhost:3080/api_jsonrpc.php
-ZABBIX_API_USER=Admin
-ZABBIX_API_PASSWORD=zabbix
+export ZABBIX_API_URL=http://localhost:3080/api_jsonrpc.php
+export ZABBIX_API_USER=Admin
+export ZABBIX_API_PASSWORD=zabbix
 
 cargo test


### PR DESCRIPTION
- without example on my rockylinux 9 test box
```
[me@rocky9t01a zabbix-api-rs]$ ./run-integration-tests.sh
    Finished test [unoptimized + debuginfo] target(s) in 0.09s
     Running unittests src/lib.rs (target/debug/deps/zabbix_api-3cf3010a4bb68ef2)

running 12 tests
test client::v6::tests::create_item ... ok
test client::v6::tests::create_web_scenario ... ok
test client::v6::tests::get_api_info ... ok
test client::v6::tests::create_trigger ... ok
test client::v6::tests::create_host_group_and_host ... ok
test client::v6::tests::get_host_groups_test ... ok
test client::v6::tests::get_hosts_test ... ok
test client::v6::tests::get_items_test ... ok
test client::v6::tests::raw_api_call_test ... ok
test client::v6::tests::get_webscenarios_test ... ok
test client::v6::tests::session_should_be_returned ... ok
test client::v6::tests::get_triggers_test ... ok

test result: ok. 12 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests zabbix-api

running 2 tests
test src/client/mod.rs - client::ZabbixApiClient::create_host (line 88) ... FAILED
test src/client/mod.rs - client::ZabbixApiClient::get_hosts (line 37) ... FAILED

failures:

---- src/client/mod.rs - client::ZabbixApiClient::create_host (line 88) stdout ----
error: environment variable `ZABBIX_API_URL` not defined at compile time
  --> src/client/mod.rs:102:21
   |
17 | let zabbix_server = env!("ZABBIX_API_URL");
   |                     ^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: use `std::env::var("ZABBIX_API_URL")` to read the variable at run time
   = note: this error originates in the macro `env` (in Nightly builds, run with -Z macro-backtrace for more info)

error: aborting due to 1 previous error

Couldn't compile the test.
---- src/client/mod.rs - client::ZabbixApiClient::get_hosts (line 37) stdout ----
error: environment variable `ZABBIX_API_URL` not defined at compile time
  --> src/client/mod.rs:58:21
   |
24 | let zabbix_server = env!("ZABBIX_API_URL");
   |                     ^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: use `std::env::var("ZABBIX_API_URL")` to read the variable at run time
   = note: this error originates in the macro `env` (in Nightly builds, run with -Z macro-backtrace for more info)

error: aborting due to 1 previous error

Couldn't compile the test.

failures:
    src/client/mod.rs - client::ZabbixApiClient::create_host (line 88)
    src/client/mod.rs - client::ZabbixApiClient::get_hosts (line 37)

test result: FAILED. 0 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.07s

error: doctest failed, to rerun pass `--doc`
[me@rocky9t01a zabbix-api-rs]$ 
```