### PR TITLE
Implement creating host with encryption connect, update host status and delete hosts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,12 +82,12 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.7"
+version = "3.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+checksum = "6680de5231bd6ee4c6191b8a1325daa282b415391ec9d3a37bd34f2060dc73fa"
 dependencies = [
  "anstyle",
- "once_cell",
+ "once_cell_polyfill",
  "windows-sys 0.59.0",
 ]
 
@@ -144,9 +144,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.22"
+version = "1.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32db95edf998450acc7881c932f94cd9b05c87b4b2599e8bab064753da4acfd1"
+checksum = "d0fc897dc1e865cc67c0e05a836d9d3f1df3cbe442aa4a9473b18e12624a4951"
 dependencies = [
  "shlex",
 ]
@@ -526,11 +526,10 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.5"
+version = "0.27.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
+checksum = "03a01595e11bdcec50946522c32dde3fc6914743000a68b93000965f2f02406d"
 dependencies = [
- "futures-util",
  "http",
  "hyper",
  "hyper-util",
@@ -559,22 +558,28 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.11"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497bbc33a26fdd4af9ed9c70d63f61cf56a938375fbb32df34db9b1cd6d643f2"
+checksum = "b1c293b6b3d21eca78250dc7dbebd6b9210ec5530e038cbfe0661b5c47ab06e8"
 dependencies = [
+ "base64",
  "bytes",
  "futures-channel",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -650,9 +655,9 @@ checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
 
 [[package]]
 name = "icu_properties"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2549ca8c7241c82f59c80ba2a6f415d931c5b58d24fb8412caa1a1f02c49139a"
+checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
 dependencies = [
  "displaydoc",
  "icu_collections",
@@ -666,9 +671,9 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8197e866e47b68f8f7d95249e172903bec06004b18b2937f1095d40a0c57de04"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
 
 [[package]]
 name = "icu_provider"
@@ -743,6 +748,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
+name = "iri-string"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -756,9 +771,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jiff"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02000660d30638906021176af16b17498bd0d12813dbfe7b276d8bc7f3c0806"
+checksum = "a194df1107f33c79f4f93d02c80798520551949d59dfad22b6157048a88cca93"
 dependencies = [
  "jiff-static",
  "log",
@@ -769,9 +784,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c30758ddd7188629c6713fc45d1188af4f44c90582311d0c8d8c9907f60c48"
+checksum = "6c6e1db7ed32c6c71b759497fae34bf7933636f75a251b9e736555da426f6442"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -835,13 +850,13 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -892,10 +907,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
-name = "openssl"
-version = "0.10.72"
+name = "once_cell_polyfill"
+version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
+name = "openssl"
+version = "0.10.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -925,9 +946,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.108"
+version = "0.9.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e145e1651e858e820e4860f7b9c5e169bc1d8ce1c86043be79fa7b7634821847"
+checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
 dependencies = [
  "cc",
  "libc",
@@ -1082,9 +1103,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.15"
+version = "0.12.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
+checksum = "e98ff6b0dbbe4d5a37318f433d4fc82babd21631f194d370409ceb2e40b2f0b5"
 dependencies = [
  "base64",
  "bytes",
@@ -1108,21 +1129,20 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
- "system-configuration",
  "tokio",
  "tokio-native-tls",
  "tower",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "windows-registry",
 ]
 
 [[package]]
@@ -1172,15 +1192,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "rustls-pki-types"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1202,9 +1213,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
 name = "ryu"
@@ -1341,9 +1352,9 @@ checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "socket2"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -1495,9 +1506,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.45.0"
+version = "1.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
+checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
 dependencies = [
  "backtrace",
  "bytes",
@@ -1552,6 +1563,24 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper",
  "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fdb0c213ca27a9f57ab69ddb290fd80d970922355b83ae380b395d3986b8a2e"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
  "tower-layer",
  "tower-service",
 ]
@@ -1741,15 +1770,15 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.61.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link",
  "windows-result",
- "windows-strings 0.4.0",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]
@@ -1793,9 +1822,9 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
  "windows-link",
 ]
@@ -1811,9 +1840,9 @@ dependencies = [
 
 [[package]]
 name = "windows-strings"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link",
 ]

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Check [examples](examples) directory.
   - [x] User
 - [ ] Delete
   - [ ] Host Group
-  - [ ] Host
+  - [x] Host
   - [ ] Item
   - [ ] Trigger
   - [ ] Web-scenario

--- a/README.md
+++ b/README.md
@@ -43,6 +43,31 @@ Check [examples](examples) directory.
   - [ ] User Group
   - [ ] User
 
+## Disclaimer
+
+As of May 2025, the integration tests failed on a just initialized zabbix-server/mysql.
+The integration tests work by starting a mysql server, a zabbix server and a zabbix web
+interface using docker-compose.
+On every first run post-start of zabbix-server, the following error is observed:
+
+```
+{"jsonrpc":"2.0","error":{"code":-32500,"message":"Application error.","data":"DBEXECUTE_ERROR"},"id":1}
+```
+
+This error was also described in [issue ZBX-9916](https://support.zabbix.com/browse/ZBX-9916).
+It seems to only occur the first time the tests are run.
+
+In the container, zabbix-web logs the following error:
+
+```
+WARNING: [pool zabbix] child 45 said into stderr:
+"PHP Warning:  Error in query [INSERT INTO ids (table_name,field_name,nextid) VALUES ('hstgrp','groupid',22)] [Deadlock found when trying to get lock; try restarting transaction]
+    in /usr/share/zabbix/include/db.inc.php on line 249"
+```
+
+This error seems to come from zabbix itself and is never triggered when re-running
+integration tests.
+
 ## RoadMap
 
 - Add missing fields for models

--- a/examples/create_host_example.rs
+++ b/examples/create_host_example.rs
@@ -70,6 +70,7 @@ fn main() -> Result<(), ZabbixApiError> {
         macros: vec![],    // Optional: Add host macros if needed
         inventory_mode: 0, // Optional: Inventory mode (0 for disabled)
         inventory: HashMap::new(), // Optional: Host inventory
+        ..Default::default() // Instead of all the vec![] above, you can just replace by default()
     };
 
     println!(

--- a/examples/create_webscenario_example.rs
+++ b/examples/create_webscenario_example.rs
@@ -55,12 +55,8 @@ fn main() -> Result<(), ZabbixApiError> {
         groups: vec![ZabbixHostGroupId {
             group_id: group_id.clone(),
         }],
-        interfaces: vec![], // No interfaces needed for a simple web scenario example
-        tags: vec![],
-        templates: vec![],
-        macros: vec![],
-        inventory_mode: 0,
-        inventory: std::collections::HashMap::new(),
+        // No interfaces needed for a simple web scenario example
+        ..Default::default()
     };
 
     let host_id = match client.create_host(&session, &create_host_request) {

--- a/examples/get_items_example.rs
+++ b/examples/get_items_example.rs
@@ -1,9 +1,8 @@
 use reqwest::blocking::Client;
-use serde::Serialize;
 use std::env;
 use zabbix_api::client::client::{ZabbixApiClient, ZabbixApiClientImpl};
 use zabbix_api::error::ZabbixApiError;
-use zabbix_api::item::get::{GetItemsRequestByKey, SearchByKey}; // Ensure this path is correct
+use zabbix_api::item::get::{GetItemsRequestByKey};
 
 fn main() -> Result<(), ZabbixApiError> {
     let zabbix_api_url =

--- a/examples/get_user_groups_example.rs
+++ b/examples/get_user_groups_example.rs
@@ -1,5 +1,4 @@
 use reqwest::blocking::Client;
-use serde::Serialize;
 // std::env is not used as credentials are hardcoded
 use zabbix_api::client::client::{ZabbixApiClient, ZabbixApiClientImpl};
 use zabbix_api::error::ZabbixApiError;

--- a/run-integration-tests-v6.sh
+++ b/run-integration-tests-v6.sh
@@ -4,5 +4,5 @@ export ZABBIX_API_URL=http://localhost:3080/api_jsonrpc.php
 export ZABBIX_API_USER=Admin
 export ZABBIX_API_PASSWORD=zabbix
 
-cargo test --features v6,full
-cargo test --doc --features v6,full
+cargo test --no-default-features --features v6,full
+cargo test --doc --no-default-features --features v6,full

--- a/src/client/client.rs
+++ b/src/client/client.rs
@@ -522,6 +522,7 @@ pub trait ZabbixApiClient {
     ///     macros: vec![],
     ///     inventory_mode: 0, // 0: disabled, 1: automatic, -1: manual
     ///     inventory: HashMap::new(),
+    ///     ..Default::default()
     /// };
     ///
     /// match client.create_host(&session, &create_host_params) {
@@ -1947,10 +1948,12 @@ mod tests {
     use crate::hostgroup::get::GetHostGroupsRequest;
     use crate::item::create::CreateItemRequest;
     use crate::item::get::GetItemsRequestById;
+    use crate::host::create::TlsConfig;
     use crate::tests::builder::TestEnvBuilder;
     use crate::tests::integration::{are_integration_tests_enabled, get_integration_tests_config};
     use crate::tests::logging::init_logging;
     use crate::tests::strings::get_random_string;
+    use crate::tests::strings::get_random_hex_string;
     use crate::trigger::create::CreateTriggerRequest;
     use crate::trigger::get::GetTriggerByIdRequest;
     use crate::usergroup::model::{CreateUserGroupRequest, UserGroupPermission, UserGroupUser};
@@ -2108,9 +2111,9 @@ mod tests {
             test_env
                 .get_session()
                 .create_host_group(&group_name)
-                .create_host(&host_name1)
-                .create_host(&host_name2)
-                .create_host(&host_name3);
+                .create_host(&host_name1, None)
+                .create_host(&host_name2, None)
+                .create_host(&host_name3, None);
 
             #[derive(Serialize)]
             struct Filter {
@@ -2160,9 +2163,9 @@ mod tests {
             test_env
                 .get_session()
                 .create_host_group(&group_name)
-                .create_host(&host_name1)
-                .create_host(&host_name2)
-                .create_host(&host_name3)
+                .create_host(&host_name1, None)
+                .create_host(&host_name2, None)
+                .create_host(&host_name3, None)
                 .create_item(&item_name, &item_key);
 
             #[derive(Serialize)]
@@ -2216,7 +2219,7 @@ mod tests {
             test_env
                 .get_session()
                 .create_host_group(&group_name)
-                .create_host(&host_name)
+                .create_host(&host_name, None)
                 .create_item(&item_name, &item_key)
                 .create_trigger(
                     &trigger_description,
@@ -2265,7 +2268,7 @@ mod tests {
             test_env
                 .get_session()
                 .create_host_group(&group_name)
-                .create_host(&host_name)
+                .create_host(&host_name, None)
                 .create_item(&item_name, &item_key)
                 .create_trigger(
                     &trigger_description,
@@ -2314,10 +2317,53 @@ mod tests {
             test_env
                 .get_session()
                 .create_host_group(&group_name)
-                .create_host(&host_name);
+                .create_host(&host_name, None);
 
             assert!(test_env.latest_host_group_id > 0);
             assert!(test_env.latest_host_id > 0);
+        }
+    }
+
+    #[test]
+    fn create_host_with_cert() {
+        init_logging();
+
+        if are_integration_tests_enabled() {
+            let mut test_env = TestEnvBuilder::build();
+
+            let group_name = get_random_string();
+            let host_name = get_random_string();
+
+            test_env
+                .get_session()
+                .create_host_group(&group_name)
+                .create_host(&host_name, Some(TlsConfig::new_cert("CN=some issuer".to_string(), "CN=some subject".to_string())));
+
+            assert!(test_env.latest_host_group_id > 0);
+            assert!(test_env.latest_host_id > 0);
+        }
+    }
+
+    #[test]
+    fn create_host_with_psk() {
+        init_logging();
+
+        if are_integration_tests_enabled() {
+            let mut test_env = TestEnvBuilder::build();
+
+            let group_name = get_random_string();
+            let host_name = get_random_string();
+
+            test_env
+                .get_session()
+                .create_host_group(&group_name)
+                .create_host(&host_name, Some(TlsConfig::new_psk(get_random_string(), get_random_hex_string())));
+
+            assert!(test_env.latest_host_group_id > 0);
+            assert!(test_env.latest_host_id > 0);
+        }
+    }
+
         }
     }
 
@@ -2334,7 +2380,7 @@ mod tests {
             test_env
                 .get_session()
                 .create_host_group(&group_name)
-                .create_host(&host_name);
+                .create_host(&host_name, None);
 
             let item_key = get_random_string();
             let item_name = get_random_string();
@@ -2382,7 +2428,7 @@ mod tests {
             test_env
                 .get_session()
                 .create_host_group(&group_name)
-                .create_host(&host_name)
+                .create_host(&host_name, None)
                 .create_item(&item_name, &item_key);
 
             let trigger_description = get_random_string();
@@ -2428,7 +2474,7 @@ mod tests {
             test_env
                 .get_session()
                 .create_host_group(&group_name)
-                .create_host(&host_name);
+                .create_host(&host_name, None);
 
             let web_scenario_name = get_random_string();
 

--- a/src/client/post.rs
+++ b/src/client/post.rs
@@ -17,6 +17,10 @@ pub fn send_post_request<T: Serialize>(
 
     let request_body = serde_json::to_string(&request)?;
 
+    debug!("---[HTTP REQUEST]----");
+    debug!("{}", request_body);
+    debug!("---[/HTTP REQUEST]----");
+
     let mut http_request_builder = client
         .post(url)
         .body(request_body)

--- a/src/host/create.rs
+++ b/src/host/create.rs
@@ -9,6 +9,47 @@ use crate::{
 
 use super::model::{ZabbixHostInterface, ZabbixHostTag};
 
+const PSK: u8 = 2;
+const CERT: u8 = 4;
+
+#[derive(Serialize, Debug)]
+pub struct TlsConfig {
+    tls_connect: u8,
+    tls_accept: u8,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tls_psk_identity: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tls_psk: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tls_issuer: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tls_subject: Option<String>,
+}
+
+impl TlsConfig {
+    pub fn new_psk(psk_identity: String, psk: String) -> TlsConfig {
+        TlsConfig {
+            tls_connect: PSK,
+            tls_accept: PSK,
+            tls_psk_identity: Some(psk_identity),
+            tls_psk: Some(psk),
+            tls_issuer: None,
+            tls_subject: None,
+        }
+    }
+
+    pub fn new_cert(issuer: String, subject: String) -> TlsConfig {
+        TlsConfig {
+            tls_connect: CERT,
+            tls_accept: CERT,
+            tls_psk_identity: None,
+            tls_psk: None,
+            tls_issuer: Some(issuer),
+            tls_subject: Some(subject),
+        }
+    }
+}
+
 /// API: https://www.zabbix.com/documentation/6.0/en/manual/api/reference/host/create
 #[derive(Serialize, Debug)]
 pub struct CreateHostRequest {
@@ -20,6 +61,25 @@ pub struct CreateHostRequest {
     pub macros: Vec<ZabbixHostMacro>,
     pub inventory_mode: u8,
     pub inventory: HashMap<String, String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(flatten)]
+    pub tls_config: Option<TlsConfig>,
+}
+
+impl Default for CreateHostRequest {
+    fn default() -> CreateHostRequest {
+        CreateHostRequest {
+            host: "".to_string(),
+            groups: Vec::new(),
+            interfaces: Vec::new(),
+            tags: Vec::new(),
+            templates: Vec::new(),
+            macros: Vec::new(),
+            inventory_mode: 0,
+            inventory: HashMap::new(),
+            tls_config: None,
+        }
+    }
 }
 
 #[derive(Deserialize, Debug)]

--- a/src/host/create.rs
+++ b/src/host/create.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     hostgroup::model::ZabbixHostGroupId, r#macro::model::ZabbixHostMacro,
-    template::model::ZabbixTemplate,
+    template::model::ZabbixTemplateId,
 };
 
 use super::model::{ZabbixHostInterface, ZabbixHostTag};
@@ -57,7 +57,7 @@ pub struct CreateHostRequest {
     pub groups: Vec<ZabbixHostGroupId>,
     pub interfaces: Vec<ZabbixHostInterface>,
     pub tags: Vec<ZabbixHostTag>,
-    pub templates: Vec<ZabbixTemplate>,
+    pub templates: Vec<ZabbixTemplateId>,
     pub macros: Vec<ZabbixHostMacro>,
     pub inventory_mode: u8,
     pub inventory: HashMap<String, String>,

--- a/src/host/get.rs
+++ b/src/host/get.rs
@@ -5,3 +5,8 @@ use serde::Serialize;
 pub struct GetHostsRequest<R> {
     pub filter: R,
 }
+
+#[derive(Serialize, Debug)]
+pub struct GetHostsByIdsRequest {
+    pub hostids: Vec<String>,
+}

--- a/src/host/mod.rs
+++ b/src/host/mod.rs
@@ -1,3 +1,4 @@
 pub mod create;
 pub mod get;
 pub mod model;
+pub mod update;

--- a/src/host/model.rs
+++ b/src/host/model.rs
@@ -1,4 +1,49 @@
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::cmp::PartialEq;
+use std::str::FromStr;
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum HostStatus {
+    Enabled,
+    Disabled,
+}
+
+impl Serialize for HostStatus {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let value = match self {
+            HostStatus::Enabled => "0",
+            HostStatus::Disabled => "1",
+        };
+
+        serializer.serialize_str(value)
+    }
+}
+
+impl<'de> Deserialize<'de> for HostStatus {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+
+        HostStatus::from_str(&value).map_err(|_| serde::de::Error::custom(format!("Invalid HostStatus value: {}", value)))
+    }
+}
+
+impl FromStr for HostStatus {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "0" => Ok(HostStatus::Enabled),
+            "1" => Ok(HostStatus::Disabled),
+            _ => Err(()),
+        }
+    }
+}
 
 /// API Object: https://www.zabbix.com/documentation/6.0/en/manual/api/reference/host/object
 #[derive(Deserialize, PartialEq, Clone, Debug)]
@@ -6,6 +51,7 @@ pub struct ZabbixHost {
     #[serde(rename = "hostid")]
     pub host_id: String,
     pub host: String,
+    pub status: HostStatus,
 }
 
 // API Object: https://www.zabbix.com/documentation/6.0/en/manual/api/reference/host/object#host-tag

--- a/src/host/update.rs
+++ b/src/host/update.rs
@@ -1,0 +1,32 @@
+use serde::{Deserialize, Serialize};
+use crate::host::model::HostStatus;
+
+/// Represents a host update request in Zabbix API
+#[derive(Debug, Serialize)]
+pub struct UpdateHostRequest {
+    /// The ID of the host to update
+    pub hostid: String,
+    pub status: HostStatus,
+}
+
+impl UpdateHostRequest {
+    /// Creates a new `UpdateHost` with the given host ID and disabled status (status = 1)
+    ///
+    /// # Arguments
+    /// * `hostid` - The ID of the host to disable
+    ///
+    /// # Returns
+    /// A new `UpdateHost` instance with status set to 1 (disabled)
+    pub fn disable_host(hostid: String) -> Self {
+        Self {
+            hostid,
+            status: HostStatus::Disabled,
+        }
+    }
+}
+
+#[derive(Deserialize, Debug)]
+pub struct UpdateHostResponse {
+    #[serde(rename = "hostids")]
+    pub host_ids: Vec<String>,
+}

--- a/src/template/model.rs
+++ b/src/template/model.rs
@@ -10,3 +10,17 @@ pub struct ZabbixTemplate {
     pub name: String,
     pub uuid: String,
 }
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ZabbixTemplateId {
+    #[serde(rename = "templateid")]
+    pub template_id: String,
+}
+
+impl From<ZabbixTemplate> for ZabbixTemplateId {
+    fn from(value: ZabbixTemplate) -> Self {
+        ZabbixTemplateId {
+            template_id: value.template_id,
+        }
+    }
+}

--- a/src/tests/builder.rs
+++ b/src/tests/builder.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::error::Error;
 
 use crate::client::client::{ZabbixApiClient, ZabbixApiClientImpl};
+use crate::host::create::TlsConfig;
 use crate::hostgroup::create::CreateHostGroupRequest;
 use crate::hostgroup::model::ZabbixHostGroupId;
 use crate::webscenario::model::ZabbixWebScenarioStep;
@@ -88,7 +89,7 @@ impl TestEnvBuilder {
         }
     }
 
-    pub fn create_host(&mut self, name: &str) -> &mut Self {
+    pub fn create_host(&mut self, name: &str, tls_config: Option<TlsConfig>) -> &mut Self {
         let params = CreateHostRequest {
             host: name.to_string(),
             groups: vec![ZabbixHostGroupId {
@@ -100,6 +101,8 @@ impl TestEnvBuilder {
             macros: vec![],
             inventory_mode: 0,
             inventory: HashMap::new(),
+            tls_config: tls_config,
+            ..Default::default()
         };
 
         match &self.client.create_host(&self.session, &params) {

--- a/src/tests/builder.rs
+++ b/src/tests/builder.rs
@@ -167,6 +167,19 @@ impl TestEnvBuilder {
         }
     }
 
+    pub fn delete_hosts(&mut self, host_ids: &Vec<String>) -> &mut Self {
+        match self.client.delete_hosts(&self.session, host_ids) {
+            Ok(ids) => {
+                println!("Successfully deleted hosts with IDs: {:?}", ids);
+                self
+            }
+            Err(e) => {
+                error!("Error deleting hosts: {}", e);
+                panic!("{}", e)
+            }
+        }
+    }
+
     pub fn create_item(&mut self, name: &str, key_: &str) -> &mut Self {
         let params = CreateItemRequest {
             name: name.to_string(),

--- a/src/tests/strings.rs
+++ b/src/tests/strings.rs
@@ -1,5 +1,5 @@
-use fake::{Fake, Faker};
+use fake::{Fake, StringFaker};
 
 pub fn get_random_string() -> String {
-    Faker.fake::<String>()
+    StringFaker::with(Vec::from("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"), 12..32).fake()
 }

--- a/src/tests/strings.rs
+++ b/src/tests/strings.rs
@@ -3,3 +3,8 @@ use fake::{Fake, StringFaker};
 pub fn get_random_string() -> String {
     StringFaker::with(Vec::from("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"), 12..32).fake()
 }
+
+/// Generates a random 32-character hexadecimal string (16 bytes)
+pub fn get_random_hex_string() -> String {
+    StringFaker::with(Vec::from("0123456789abcdef"), 32).fake()
+}


### PR DESCRIPTION
# Changes

## Add TlsConfig to host.create

This allows someone to create a host with tls_connect/accept.
It supports psk and certificate.

This implementation is opinionated. I prefer to force the user of the lib to choose one of None, Some(Psk) or Some(Cert) and to setup tls_accept to the same as tls_connect.

My opinion is it’s better to guide the user with a simple API rather than having to manually set:

```
tls_connect: 1 | 2 | 4,
tls_accept: 1..7
tls_subject: …
tls_issuer: …
tls_psk_identity: …
tls_psk: …
```

*I’m open to change that part!*

## Implement host.update and host.delete

On the host.update part: I only implemented the status param as I don’t need anything else. I’m open to implement a bit more, but most of it will be unused :innocent: 

