### PR TITLE
feat: add 1 mandatory and 1 optional field to create request

### DIFF
--- a/src/client/client.rs
+++ b/src/client/client.rs
@@ -494,9 +494,7 @@ pub trait ZabbixApiClient {
     /// use zabbix_api::client::client::{ZabbixApiClientImpl, ZabbixApiClient};
     /// use zabbix_api::host::create::CreateHostRequest;
     /// use zabbix_api::hostgroup::model::ZabbixHostGroupId; // For specifying group
-    /// // To use the example for interfaces in the line below (currently vec![]),
-    /// // you would uncomment this import:
-    /// // use zabbix_api::host::model::ZabbixHostInterface;
+    /// use zabbix_api::host::model::ZabbixHostInterface;
     /// // Other optional fields in CreateHostRequest might need these:
     /// // use zabbix_api::host::model::ZabbixHostTag;
     /// // use zabbix_api::template::model::ZabbixTemplate;
@@ -518,7 +516,7 @@ pub trait ZabbixApiClient {
     /// let create_host_params = CreateHostRequest {
     ///     host: new_host_name.clone(),
     ///     groups: vec![ZabbixHostGroupId { group_id: known_host_group_id.to_string() }],
-    ///     interfaces: vec![], // Add interfaces: e.g., ZabbixHostInterface { r#type: 1, main: 1, use_ip: 1, ip: "127.0.0.1".to_string(), dns: "".to_string() }
+    ///     interfaces: vec![ZabbixHostInterface { r#type: 1, main: 1, use_ip: 1, ip: "127.0.0.1".to_string(), dns: "".to_string(), port: "10050".to_string() }],
     ///     tags: vec![],
     ///     templates: vec![],
     ///     macros: vec![],

--- a/src/host/create.rs
+++ b/src/host/create.rs
@@ -54,6 +54,8 @@ impl TlsConfig {
 #[derive(Serialize, Debug)]
 pub struct CreateHostRequest {
     pub host: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
     pub groups: Vec<ZabbixHostGroupId>,
     pub interfaces: Vec<ZabbixHostInterface>,
     pub tags: Vec<ZabbixHostTag>,
@@ -70,6 +72,7 @@ impl Default for CreateHostRequest {
     fn default() -> CreateHostRequest {
         CreateHostRequest {
             host: "".to_string(),
+            name: None,
             groups: Vec::new(),
             interfaces: Vec::new(),
             tags: Vec::new(),

--- a/src/host/model.rs
+++ b/src/host/model.rs
@@ -72,6 +72,8 @@ pub struct ZabbixHostInterface {
 
     pub dns: String,
 
+    pub port: String,
+
     #[serde(rename = "useip")]
     pub use_ip: u8,
 }

--- a/src/tests/builder.rs
+++ b/src/tests/builder.rs
@@ -11,6 +11,7 @@ use log::{debug, error};
 use reqwest::blocking::Client;
 
 use crate::host::create::CreateHostRequest;
+use crate::host::model::ZabbixHostInterface;
 use crate::item::create::CreateItemRequest;
 use crate::tests::integration::{get_integration_tests_config, IntegrationTestsConfig};
 use crate::trigger::create::CreateTriggerRequest;
@@ -96,7 +97,7 @@ impl TestEnvBuilder {
             groups: vec![ZabbixHostGroupId {
                 group_id: self.latest_host_group_id.to_string(),
             }],
-            interfaces: vec![],
+            interfaces: vec![ZabbixHostInterface { r#type: 1, main: 1, use_ip: 1, ip: "127.0.0.1".to_string(), dns: "".to_string(), port: "10050".to_string() }],
             tags: vec![],
             templates: vec![],
             macros: vec![],


### PR DESCRIPTION
Add:
1. `port` to ZabbixInterface. This field is mandatory.
2. `name` to CreateHostRequest. Optional, but I need it :innocent:  