### PR TITLE
Add host inventory and builder patterns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1356,17 +1356,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_repr"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2123,7 +2112,6 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "serde_repr",
  "serde_with",
  "thiserror",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1356,6 +1356,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2104,7 +2115,7 @@ dependencies = [
 
 [[package]]
 name = "zabbix-api"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "env_logger",
  "fake",
@@ -2112,6 +2123,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "serde_repr",
  "serde_with",
  "thiserror",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ thiserror = "2.0.12"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 serde_with = "3.12.0"
-serde_repr = "0.1.1"
 
 reqwest = { version = "0.12.15", features = ["blocking", "json"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ thiserror = "2.0.12"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 serde_with = "3.12.0"
+serde_repr = "0.1.1"
 
 reqwest = { version = "0.12.15", features = ["blocking", "json"] }
 

--- a/examples/api_basics.rs
+++ b/examples/api_basics.rs
@@ -4,12 +4,13 @@ use zabbix_api::client::client::{ZabbixApiClient, ZabbixApiClientImpl};
 use zabbix_api::error::ZabbixApiError;
 
 fn main() -> Result<(), ZabbixApiError> {
-    let zabbix_api_url =
-        env::var("ZABBIX_API_URL").expect("ZABBIX_API_URL environment variable not set (e.g., http://localhost:3080/api_jsonrpc.php)");
-    let zabbix_api_user =
-        env::var("ZABBIX_API_USER").expect("ZABBIX_API_USER environment variable not set (e.g., Admin)");
-    let zabbix_api_password =
-        env::var("ZABBIX_API_PASSWORD").expect("ZABBIX_API_PASSWORD environment variable not set (e.g., zabbix)");
+    let zabbix_api_url = env::var("ZABBIX_API_URL").expect(
+        "ZABBIX_API_URL environment variable not set (e.g., http://localhost:3080/api_jsonrpc.php)",
+    );
+    let zabbix_api_user = env::var("ZABBIX_API_USER")
+        .expect("ZABBIX_API_USER environment variable not set (e.g., Admin)");
+    let zabbix_api_password = env::var("ZABBIX_API_PASSWORD")
+        .expect("ZABBIX_API_PASSWORD environment variable not set (e.g., zabbix)");
 
     let http_client = Client::new();
     let client = ZabbixApiClientImpl::new(http_client, &zabbix_api_url);
@@ -17,7 +18,10 @@ fn main() -> Result<(), ZabbixApiError> {
     // Get API Info
     match client.get_api_info() {
         Ok(api_version) => {
-            println!("Successfully connected to Zabbix API version: {}", api_version);
+            println!(
+                "Successfully connected to Zabbix API version: {}",
+                api_version
+            );
         }
         Err(e) => {
             eprintln!("Error getting API info: {}", e);
@@ -28,7 +32,10 @@ fn main() -> Result<(), ZabbixApiError> {
     // Get Auth Session
     match client.get_auth_session(&zabbix_api_user, &zabbix_api_password) {
         Ok(session_token) => {
-            println!("Successfully obtained session token (first 10 chars): {}...", &session_token[..10.min(session_token.len())]);
+            println!(
+                "Successfully obtained session token (first 10 chars): {}...",
+                &session_token[..10.min(session_token.len())]
+            );
         }
         Err(e) => {
             eprintln!("Error getting auth session: {}", e);

--- a/examples/create_host_example.rs
+++ b/examples/create_host_example.rs
@@ -1,9 +1,9 @@
 use reqwest::blocking::Client;
-use std::collections::HashMap;
 // std::env is no longer needed as credentials will be hardcoded.
 use zabbix_api::client::client::{ZabbixApiClient, ZabbixApiClientImpl};
 use zabbix_api::error::ZabbixApiError;
-use zabbix_api::host::create::CreateHostRequest;
+use zabbix_api::host::create::{CreateHostRequest, InventoryMode};
+use zabbix_api::host::model::ZabbixHostInventory;
 // ZabbixHostInterface is no longer used in this example since interfaces are empty.
 use zabbix_api::hostgroup::create::CreateHostGroupRequest;
 use zabbix_api::hostgroup::model::ZabbixHostGroupId;
@@ -65,11 +65,11 @@ fn main() -> Result<(), ZabbixApiError> {
         // interfaces: vec![ZabbixHostInterface {
         //     r#type: 1, main: 1, ip: "127.0.0.1".to_string(), dns: "".to_string(), useip: 1, port: "10050".to_string(),
         // }],
-        tags: vec![],      // Optional: Add host tags if needed
-        templates: vec![], // Optional: Link templates if needed
-        macros: vec![],    // Optional: Add host macros if needed
-        inventory_mode: 0, // Optional: Inventory mode (0 for disabled)
-        inventory: HashMap::new(), // Optional: Host inventory
+        tags: vec![],                              // Optional: Add host tags if needed
+        templates: vec![],                         // Optional: Link templates if needed
+        macros: vec![],                            // Optional: Add host macros if needed
+        inventory_mode: InventoryMode::Manual,     // Optional: Inventory mode (0 for disabled)
+        inventory: ZabbixHostInventory::default(), // Optional: Host inventory
         ..Default::default() // Instead of all the vec![] above, you can just replace by default()
     };
 

--- a/examples/create_host_group_example.rs
+++ b/examples/create_host_group_example.rs
@@ -5,12 +5,13 @@ use zabbix_api::error::ZabbixApiError;
 use zabbix_api::hostgroup::create::CreateHostGroupRequest;
 
 fn main() -> Result<(), ZabbixApiError> {
-    let zabbix_api_url =
-        env::var("ZABBIX_API_URL").expect("ZABBIX_API_URL environment variable not set (e.g., http://localhost:3080/api_jsonrpc.php)");
-    let zabbix_api_user =
-        env::var("ZABBIX_API_USER").expect("ZABBIX_API_USER environment variable not set (e.g., Admin)");
-    let zabbix_api_password =
-        env::var("ZABBIX_API_PASSWORD").expect("ZABBIX_API_PASSWORD environment variable not set (e.g., zabbix)");
+    let zabbix_api_url = env::var("ZABBIX_API_URL").expect(
+        "ZABBIX_API_URL environment variable not set (e.g., http://localhost:3080/api_jsonrpc.php)",
+    );
+    let zabbix_api_user = env::var("ZABBIX_API_USER")
+        .expect("ZABBIX_API_USER environment variable not set (e.g., Admin)");
+    let zabbix_api_password = env::var("ZABBIX_API_PASSWORD")
+        .expect("ZABBIX_API_PASSWORD environment variable not set (e.g., zabbix)");
 
     let http_client = Client::new();
     let client = ZabbixApiClientImpl::new(http_client, &zabbix_api_url);

--- a/examples/create_item_example.rs
+++ b/examples/create_item_example.rs
@@ -15,12 +15,13 @@ fn generate_unique_item_key() -> String {
 }
 
 fn main() -> Result<(), ZabbixApiError> {
-    let zabbix_api_url =
-        env::var("ZABBIX_API_URL").expect("ZABBIX_API_URL environment variable not set (e.g., http://localhost:3080/api_jsonrpc.php)");
-    let zabbix_api_user =
-        env::var("ZABBIX_API_USER").expect("ZABBIX_API_USER environment variable not set (e.g., Admin)");
-    let zabbix_api_password =
-        env::var("ZABBIX_API_PASSWORD").expect("ZABBIX_API_PASSWORD environment variable not set (e.g., zabbix)");
+    let zabbix_api_url = env::var("ZABBIX_API_URL").expect(
+        "ZABBIX_API_URL environment variable not set (e.g., http://localhost:3080/api_jsonrpc.php)",
+    );
+    let zabbix_api_user = env::var("ZABBIX_API_USER")
+        .expect("ZABBIX_API_USER environment variable not set (e.g., Admin)");
+    let zabbix_api_password = env::var("ZABBIX_API_PASSWORD")
+        .expect("ZABBIX_API_PASSWORD environment variable not set (e.g., zabbix)");
 
     // IMPORTANT: Replace with a valid host ID from your Zabbix instance
     let host_id_for_item = env::var("ZABBIX_HOST_ID_FOR_ITEM_EXAMPLE")
@@ -42,12 +43,12 @@ fn main() -> Result<(), ZabbixApiError> {
         name: item_name.clone(),
         key_: item_key.clone(),
         host_id: host_id_for_item.clone(),
-        r#type: 0, // Type 0: Zabbix agent. Adjust if using a different item type.
+        r#type: 0,     // Type 0: Zabbix agent. Adjust if using a different item type.
         value_type: 3, // Type 3: Numeric (unsigned). Adjust for other data types (e.g., 4 for Text).
         interface_id: "0".to_string(), // Use "0" for the first available agent interface, or provide a specific interface ID.
-        delay: "1m".to_string(), // Collect data every 1 minute.
+        delay: "1m".to_string(),       // Collect data every 1 minute.
         tags: Vec::<ZabbixHostTag>::new(), // Optional: Add item tags if needed. Made type explicit.
-        // Add other optional fields as necessary
+                                       // Add other optional fields as necessary
     };
 
     println!(
@@ -63,10 +64,7 @@ fn main() -> Result<(), ZabbixApiError> {
             );
         }
         Err(e) => {
-            eprintln!(
-                "Error creating item '{}': {}",
-                item_name, e
-            );
+            eprintln!("Error creating item '{}': {}", item_name, e);
             return Err(e);
         }
     }

--- a/examples/create_user_example.rs
+++ b/examples/create_user_example.rs
@@ -49,12 +49,12 @@ fn main() -> Result<(), ZabbixApiError> {
     // 2. Prepare request to create a user
     let user_alias = generate_unique_name("example_user");
     let user_password = "Password123!"; // Example password
-    // Role ID "3" is often "Admin role" or "User role" depending on Zabbix version/customization.
-    // In this project's tests, "3" is referred to as "User role".
-    // Standard Zabbix: Guest=1, User=2, Admin=3, Super Admin=4.
-    // Using "3" to align with existing test conventions if they imply a specific setup.
-    // For a generic "User role", "2" might be more standard.
-    // Let's use "2" for "User role" as it's more standard for a general example.
+                                        // Role ID "3" is often "Admin role" or "User role" depending on Zabbix version/customization.
+                                        // In this project's tests, "3" is referred to as "User role".
+                                        // Standard Zabbix: Guest=1, User=2, Admin=3, Super Admin=4.
+                                        // Using "3" to align with existing test conventions if they imply a specific setup.
+                                        // For a generic "User role", "2" might be more standard.
+                                        // Let's use "2" for "User role" as it's more standard for a general example.
     let role_id = "2"; // User role
 
     let create_user_request = CreateUserRequest {

--- a/examples/create_user_group_example.rs
+++ b/examples/create_user_group_example.rs
@@ -38,10 +38,7 @@ fn main() -> Result<(), ZabbixApiError> {
         ..Default::default() // If your struct derives Default and has more fields
     };
 
-    println!(
-        "Attempting to create user group '{}'...",
-        user_group_name
-    );
+    println!("Attempting to create user group '{}'...", user_group_name);
 
     match client.create_user_group(&session, &create_request) {
         Ok(user_group_id) => {
@@ -51,10 +48,7 @@ fn main() -> Result<(), ZabbixApiError> {
             );
         }
         Err(e) => {
-            eprintln!(
-                "Error creating user group '{}': {}",
-                user_group_name, e
-            );
+            eprintln!("Error creating user group '{}': {}", user_group_name, e);
             return Err(e);
         }
     }

--- a/examples/create_webscenario_example.rs
+++ b/examples/create_webscenario_example.rs
@@ -61,10 +61,7 @@ fn main() -> Result<(), ZabbixApiError> {
 
     let host_id = match client.create_host(&session, &create_host_request) {
         Ok(id) => {
-            println!(
-                "Successfully created host '{}' with ID: {}",
-                host_name, id
-            );
+            println!("Successfully created host '{}' with ID: {}", host_name, id);
             id.to_string()
         }
         Err(e) => {

--- a/examples/get_host_groups_example.rs
+++ b/examples/get_host_groups_example.rs
@@ -9,16 +9,17 @@ use zabbix_api::hostgroup::get::GetHostGroupsRequest; // Use the actual request 
 #[derive(Serialize)]
 struct HostGroupFilter {
     name: Vec<String>, // Example: filter by a list of names
-    // Add other filter fields as needed, e.g., hostids, groupids
+                       // Add other filter fields as needed, e.g., hostids, groupids
 }
 
 fn main() -> Result<(), ZabbixApiError> {
-    let zabbix_api_url =
-        env::var("ZABBIX_API_URL").expect("ZABBIX_API_URL environment variable not set (e.g., http://localhost:3080/api_jsonrpc.php)");
-    let zabbix_api_user =
-        env::var("ZABBIX_API_USER").expect("ZABBIX_API_USER environment variable not set (e.g., Admin)");
-    let zabbix_api_password =
-        env::var("ZABBIX_API_PASSWORD").expect("ZABBIX_API_PASSWORD environment variable not set (e.g., zabbix)");
+    let zabbix_api_url = env::var("ZABBIX_API_URL").expect(
+        "ZABBIX_API_URL environment variable not set (e.g., http://localhost:3080/api_jsonrpc.php)",
+    );
+    let zabbix_api_user = env::var("ZABBIX_API_USER")
+        .expect("ZABBIX_API_USER environment variable not set (e.g., Admin)");
+    let zabbix_api_password = env::var("ZABBIX_API_PASSWORD")
+        .expect("ZABBIX_API_PASSWORD environment variable not set (e.g., zabbix)");
 
     let http_client = Client::new();
     let client = ZabbixApiClientImpl::new(http_client, &zabbix_api_url);
@@ -41,16 +42,25 @@ fn main() -> Result<(), ZabbixApiError> {
         // selectApplications: "extend", // To get applications in the group
     };
 
-    println!("Attempting to fetch host groups with names: {:?}", group_names_to_filter);
+    println!(
+        "Attempting to fetch host groups with names: {:?}",
+        group_names_to_filter
+    );
 
     match client.get_host_groups(&session, &request_params) {
         Ok(host_groups) => {
             if host_groups.is_empty() {
-                println!("No host groups found matching the criteria: {:?}.", group_names_to_filter);
+                println!(
+                    "No host groups found matching the criteria: {:?}.",
+                    group_names_to_filter
+                );
             } else {
                 println!("Successfully fetched {} host group(s):", host_groups.len());
                 for group in host_groups {
-                    println!("  Group ID: {}, Group Name: '{}'", group.group_id, group.name);
+                    println!(
+                        "  Group ID: {}, Group Name: '{}'",
+                        group.group_id, group.name
+                    );
                     // If selectHosts was used, you could iterate group.hosts and print host details
                 }
             }

--- a/examples/get_hosts_example.rs
+++ b/examples/get_hosts_example.rs
@@ -19,12 +19,13 @@ struct GetHostsParams {
 }
 
 fn main() -> Result<(), ZabbixApiError> {
-    let zabbix_api_url =
-        env::var("ZABBIX_API_URL").expect("ZABBIX_API_URL environment variable not set (e.g., http://localhost:3080/api_jsonrpc.php)");
-    let zabbix_api_user =
-        env::var("ZABBIX_API_USER").expect("ZABBIX_API_USER environment variable not set (e.g., Admin)");
-    let zabbix_api_password =
-        env::var("ZABBIX_API_PASSWORD").expect("ZABBIX_API_PASSWORD environment variable not set (e.g., zabbix)");
+    let zabbix_api_url = env::var("ZABBIX_API_URL").expect(
+        "ZABBIX_API_URL environment variable not set (e.g., http://localhost:3080/api_jsonrpc.php)",
+    );
+    let zabbix_api_user = env::var("ZABBIX_API_USER")
+        .expect("ZABBIX_API_USER environment variable not set (e.g., Admin)");
+    let zabbix_api_password = env::var("ZABBIX_API_PASSWORD")
+        .expect("ZABBIX_API_PASSWORD environment variable not set (e.g., zabbix)");
 
     let http_client = Client::new();
     let client = ZabbixApiClientImpl::new(http_client, &zabbix_api_url);

--- a/examples/get_items_example.rs
+++ b/examples/get_items_example.rs
@@ -2,15 +2,16 @@ use reqwest::blocking::Client;
 use std::env;
 use zabbix_api::client::client::{ZabbixApiClient, ZabbixApiClientImpl};
 use zabbix_api::error::ZabbixApiError;
-use zabbix_api::item::get::{GetItemsRequestByKey};
+use zabbix_api::item::get::GetItemsRequestByKey;
 
 fn main() -> Result<(), ZabbixApiError> {
-    let zabbix_api_url =
-        env::var("ZABBIX_API_URL").expect("ZABBIX_API_URL environment variable not set (e.g., http://localhost:3080/api_jsonrpc.php)");
-    let zabbix_api_user =
-        env::var("ZABBIX_API_USER").expect("ZABBIX_API_USER environment variable not set (e.g., Admin)");
-    let zabbix_api_password =
-        env::var("ZABBIX_API_PASSWORD").expect("ZABBIX_API_PASSWORD environment variable not set (e.g., zabbix)");
+    let zabbix_api_url = env::var("ZABBIX_API_URL").expect(
+        "ZABBIX_API_URL environment variable not set (e.g., http://localhost:3080/api_jsonrpc.php)",
+    );
+    let zabbix_api_user = env::var("ZABBIX_API_USER")
+        .expect("ZABBIX_API_USER environment variable not set (e.g., Admin)");
+    let zabbix_api_password = env::var("ZABBIX_API_PASSWORD")
+        .expect("ZABBIX_API_PASSWORD environment variable not set (e.g., zabbix)");
 
     let http_client = Client::new();
     let client = ZabbixApiClientImpl::new(http_client, &zabbix_api_url);
@@ -42,7 +43,6 @@ fn main() -> Result<(), ZabbixApiError> {
     //     filter: ItemFilterForGet { hostid: "your_host_id".to_string() },
     // };
 
-
     println!("Searching for items with key '{}'...", item_key_to_search);
 
     match client.get_items(&session, &request_params) {
@@ -50,7 +50,11 @@ fn main() -> Result<(), ZabbixApiError> {
             if items.is_empty() {
                 println!("No items found matching the key '{}'.", item_key_to_search);
             } else {
-                println!("Successfully fetched {} item(s) with key '{}':", items.len(), item_key_to_search);
+                println!(
+                    "Successfully fetched {} item(s) with key '{}':",
+                    items.len(),
+                    item_key_to_search
+                );
                 for item in items {
                     println!(
                         "  Name: '{}', Key: '{}', Host ID: {}",

--- a/examples/get_triggers_example.rs
+++ b/examples/get_triggers_example.rs
@@ -26,12 +26,13 @@ struct GetTriggersParams {
 // }
 
 fn main() -> Result<(), ZabbixApiError> {
-    let zabbix_api_url =
-        env::var("ZABBIX_API_URL").expect("ZABBIX_API_URL environment variable not set (e.g., http://localhost:3080/api_jsonrpc.php)");
-    let zabbix_api_user =
-        env::var("ZABBIX_API_USER").expect("ZABBIX_API_USER environment variable not set (e.g., Admin)");
-    let zabbix_api_password =
-        env::var("ZABBIX_API_PASSWORD").expect("ZABBIX_API_PASSWORD environment variable not set (e.g., zabbix)");
+    let zabbix_api_url = env::var("ZABBIX_API_URL").expect(
+        "ZABBIX_API_URL environment variable not set (e.g., http://localhost:3080/api_jsonrpc.php)",
+    );
+    let zabbix_api_user = env::var("ZABBIX_API_USER")
+        .expect("ZABBIX_API_USER environment variable not set (e.g., Admin)");
+    let zabbix_api_password = env::var("ZABBIX_API_PASSWORD")
+        .expect("ZABBIX_API_PASSWORD environment variable not set (e.g., zabbix)");
 
     let http_client = Client::new();
     let client = ZabbixApiClientImpl::new(http_client, &zabbix_api_url);

--- a/examples/get_user_groups_example.rs
+++ b/examples/get_user_groups_example.rs
@@ -28,7 +28,7 @@ fn main() -> Result<(), ZabbixApiError> {
     let request_params = GetUserGroupsRequest {
         output: Some("extend".to_string()),
         select_users: Some("extend".to_string()), // To get users in the group
-        filter: Option::<UserGroupFilter>::None, // No filter, get all groups
+        filter: Option::<UserGroupFilter>::None,  // No filter, get all groups
         // You can add other parameters like:
         // status: Some(0), // To get enabled groups
         // select_rights: Some("extend"), // To get group rights
@@ -57,7 +57,10 @@ fn main() -> Result<(), ZabbixApiError> {
                         } else {
                             println!("    Users ({}):", users.len());
                             for user in users {
-                                println!("      - User ID: {}, Alias: '{}'", user.user_id, user.alias);
+                                println!(
+                                    "      - User ID: {}, Alias: '{}'",
+                                    user.user_id, user.alias
+                                );
                             }
                         }
                     }

--- a/examples/get_users_example.rs
+++ b/examples/get_users_example.rs
@@ -26,12 +26,13 @@ struct GetUsersParams {
 // }
 
 fn main() -> Result<(), ZabbixApiError> {
-    let zabbix_api_url =
-        env::var("ZABBIX_API_URL").expect("ZABBIX_API_URL environment variable not set (e.g., http://localhost:3080/api_jsonrpc.php)");
-    let zabbix_api_user =
-        env::var("ZABBIX_API_USER").expect("ZABBIX_API_USER environment variable not set (e.g., Admin)");
-    let zabbix_api_password =
-        env::var("ZABBIX_API_PASSWORD").expect("ZABBIX_API_PASSWORD environment variable not set (e.g., zabbix)");
+    let zabbix_api_url = env::var("ZABBIX_API_URL").expect(
+        "ZABBIX_API_URL environment variable not set (e.g., http://localhost:3080/api_jsonrpc.php)",
+    );
+    let zabbix_api_user = env::var("ZABBIX_API_USER")
+        .expect("ZABBIX_API_USER environment variable not set (e.g., Admin)");
+    let zabbix_api_password = env::var("ZABBIX_API_PASSWORD")
+        .expect("ZABBIX_API_PASSWORD environment variable not set (e.g., zabbix)");
 
     let http_client = Client::new();
     let client = ZabbixApiClientImpl::new(http_client, &zabbix_api_url);

--- a/examples/get_webscenarios_example.rs
+++ b/examples/get_webscenarios_example.rs
@@ -26,12 +26,13 @@ fn main() -> Result<(), ZabbixApiError> {
     // For this example, we'll assume logging is initialized if needed elsewhere or skip for simplicity.
     // env_logger::init();
 
-    let zabbix_api_url =
-        env::var("ZABBIX_API_URL").expect("ZABBIX_API_URL environment variable not set (e.g., http://localhost:3080/api_jsonrpc.php)");
-    let zabbix_api_user =
-        env::var("ZABBIX_API_USER").expect("ZABBIX_API_USER environment variable not set (e.g., Admin)");
-    let zabbix_api_password =
-        env::var("ZABBIX_API_PASSWORD").expect("ZABBIX_API_PASSWORD environment variable not set (e.g., zabbix)");
+    let zabbix_api_url = env::var("ZABBIX_API_URL").expect(
+        "ZABBIX_API_URL environment variable not set (e.g., http://localhost:3080/api_jsonrpc.php)",
+    );
+    let zabbix_api_user = env::var("ZABBIX_API_USER")
+        .expect("ZABBIX_API_USER environment variable not set (e.g., Admin)");
+    let zabbix_api_password = env::var("ZABBIX_API_PASSWORD")
+        .expect("ZABBIX_API_PASSWORD environment variable not set (e.g., zabbix)");
 
     let http_client = Client::new();
     let client = ZabbixApiClientImpl::new(http_client, &zabbix_api_url);
@@ -54,7 +55,10 @@ fn main() -> Result<(), ZabbixApiError> {
             if webscenarios.is_empty() {
                 println!("No web scenarios found matching the criteria.");
             } else {
-                println!("Successfully fetched {} web scenario(s):", webscenarios.len());
+                println!(
+                    "Successfully fetched {} web scenario(s):",
+                    webscenarios.len()
+                );
                 for scenario in webscenarios {
                     println!(
                         "\n  Scenario Name: '{}', Host ID: {}",

--- a/src/client/client.rs
+++ b/src/client/client.rs
@@ -492,9 +492,9 @@ pub trait ZabbixApiClient {
     /// use std::collections::HashMap;
     /// use reqwest::blocking::Client;
     /// use zabbix_api::client::client::{ZabbixApiClientImpl, ZabbixApiClient};
-    /// use zabbix_api::host::create::CreateHostRequest;
+    /// use zabbix_api::host::create::{CreateHostRequest, InventoryMode};
     /// use zabbix_api::hostgroup::model::ZabbixHostGroupId; // For specifying group
-    /// use zabbix_api::host::model::ZabbixHostInterface;
+    /// use zabbix_api::host::model::{ZabbixHostInterface, ZabbixHostInventory};
     /// // Other optional fields in CreateHostRequest might need these:
     /// // use zabbix_api::host::model::ZabbixHostTag;
     /// // use zabbix_api::template::model::ZabbixTemplate;
@@ -520,8 +520,8 @@ pub trait ZabbixApiClient {
     ///     tags: vec![],
     ///     templates: vec![],
     ///     macros: vec![],
-    ///     inventory_mode: 0, // 0: disabled, 1: automatic, -1: manual
-    ///     inventory: HashMap::new(),
+    ///     inventory_mode: InventoryMode::Manual, // 0: disabled, 1: automatic, -1: manual
+    ///     inventory: ZabbixHostInventory::default(),
     ///     ..Default::default()
     /// };
     ///
@@ -800,7 +800,7 @@ pub trait ZabbixApiClient {
     ///     users: Some(vec![UserGroupUser {
     ///         user_id: "1".to_string(), // User ID to add to the group
     ///     }]),
-    ///     debug_mode: None,
+    ///     debug_mode: 0,
     ///     templategroup_rights: None, // Added missing field
     ///     tag_filters: None,
     /// };

--- a/src/client/client.rs
+++ b/src/client/client.rs
@@ -2132,18 +2132,18 @@ mod tests {
     use serde::Serialize;
 
     use crate::client::client::ZabbixApiClient;
+    use crate::host::create::TlsConfig;
     use crate::host::get::GetHostsRequest;
     use crate::host::model::ZabbixHost;
+    use crate::host::update::UpdateHostRequest;
     use crate::hostgroup::get::GetHostGroupsRequest;
     use crate::item::create::CreateItemRequest;
     use crate::item::get::GetItemsRequestById;
-    use crate::host::create::TlsConfig;
-    use crate::host::update::UpdateHostRequest;
     use crate::tests::builder::TestEnvBuilder;
     use crate::tests::integration::{are_integration_tests_enabled, get_integration_tests_config};
     use crate::tests::logging::init_logging;
-    use crate::tests::strings::get_random_string;
     use crate::tests::strings::get_random_hex_string;
+    use crate::tests::strings::get_random_string;
     use crate::trigger::create::CreateTriggerRequest;
     use crate::trigger::get::GetTriggerByIdRequest;
     use crate::usergroup::model::{CreateUserGroupRequest, UserGroupPermission, UserGroupUser};
@@ -2361,17 +2361,25 @@ mod tests {
                 .create_host(&host_name2, None)
                 .create_host(&host_name3, None);
 
-            match test_env.client.get_hosts(&test_env.session, &GetHostsRequest { filter: HostFilter { host: vec![host_name1, host_name2, host_name3] } }) {
+            match test_env.client.get_hosts(
+                &test_env.session,
+                &GetHostsRequest {
+                    filter: HostFilter {
+                        host: vec![host_name1, host_name2, host_name3],
+                    },
+                },
+            ) {
                 Ok(hosts) => {
-                    let host_ids = hosts.iter().map(|host| host.host_id.clone()).collect::<Vec<String>>();
+                    let host_ids = hosts
+                        .iter()
+                        .map(|host| host.host_id.clone())
+                        .collect::<Vec<String>>();
 
                     test_env.get_session().delete_hosts(&host_ids);
 
                     match test_env.client.get_hosts(
                         &test_env.session,
-                        &GetHostsByIdsRequest {
-                            hostids: host_ids,
-                        },
+                        &GetHostsByIdsRequest { hostids: host_ids },
                     ) {
                         Ok(hosts) => {
                             assert!(hosts.is_empty());
@@ -2589,7 +2597,13 @@ mod tests {
             test_env
                 .get_session()
                 .create_host_group(&group_name)
-                .create_host(&host_name, Some(TlsConfig::new_cert("CN=some issuer".to_string(), "CN=some subject".to_string())));
+                .create_host(
+                    &host_name,
+                    Some(TlsConfig::new_cert(
+                        "CN=some issuer".to_string(),
+                        "CN=some subject".to_string(),
+                    )),
+                );
 
             assert!(test_env.latest_host_group_id > 0);
             assert!(test_env.latest_host_id > 0);
@@ -2609,7 +2623,13 @@ mod tests {
             test_env
                 .get_session()
                 .create_host_group(&group_name)
-                .create_host(&host_name, Some(TlsConfig::new_psk(get_random_string(), get_random_hex_string())));
+                .create_host(
+                    &host_name,
+                    Some(TlsConfig::new_psk(
+                        get_random_string(),
+                        get_random_hex_string(),
+                    )),
+                );
 
             assert!(test_env.latest_host_group_id > 0);
             assert!(test_env.latest_host_id > 0);
@@ -2635,7 +2655,9 @@ mod tests {
             assert!(test_env.latest_host_id > 0);
 
             let host_id = test_env.latest_host_id.to_string();
-            test_env.get_session().update_host(UpdateHostRequest::disable_host(host_id));
+            test_env
+                .get_session()
+                .update_host(UpdateHostRequest::disable_host(host_id));
         }
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,29 +15,31 @@ pub enum ZabbixApiError {
     #[error("zabbix api call error")]
     ApiCallError {
         #[source]
-        zabbix: ZabbixError
+        zabbix: ZabbixError,
     },
 
     #[error("zabbix api bad request error")]
     BadRequestError,
 
     #[error("zabbix api error")]
-    Error
+    Error,
 }
 
-#[derive(Deserialize,Debug)]
+#[derive(Deserialize, Debug)]
 pub struct ZabbixError {
     pub code: i32,
     pub message: String,
-    pub data: String
+    pub data: String,
 }
 
 impl Display for ZabbixError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "[zabbix error] code {}, message '{}', data: '{}' [/zabbix error]", self.code, self.message, self.data)
+        write!(
+            f,
+            "[zabbix error] code {}, message '{}', data: '{}' [/zabbix error]",
+            self.code, self.message, self.data
+        )
     }
 }
 
-impl StdError for ZabbixError {
-
-}
+impl StdError for ZabbixError {}

--- a/src/host/create.rs
+++ b/src/host/create.rs
@@ -2,14 +2,13 @@ use super::model::{ZabbixHostInterface, ZabbixHostInventory, ZabbixHostTag};
 use crate::r#macro::create::CreateZabbixHostMacro;
 use crate::{hostgroup::model::ZabbixHostGroupId, template::model::ZabbixTemplateId};
 use serde::{Deserialize, Serialize};
-use serde_repr::{Deserialize_repr, Serialize_repr};
 use serde_with::skip_serializing_none;
 
 const PSK: u8 = 2;
 const CERT: u8 = 4;
 
-#[derive(Serialize, Debug)]
 #[skip_serializing_none]
+#[derive(Serialize, Debug)]
 pub struct TlsConfig {
     tls_connect: u8,
     tls_accept: u8,
@@ -44,8 +43,8 @@ impl TlsConfig {
 }
 
 /// API: https://www.zabbix.com/documentation/6.0/en/manual/api/reference/host/create
-#[derive(Serialize, Debug, Default)]
 #[skip_serializing_none]
+#[derive(Serialize, Debug, Default)]
 pub struct CreateHostRequest {
     pub host: String,
     pub name: Option<String>,
@@ -60,13 +59,15 @@ pub struct CreateHostRequest {
     pub tls_config: Option<TlsConfig>,
 }
 
-#[derive(Debug, Clone, Copy, Default, Deserialize_repr, Serialize_repr)]
-#[repr(i8)]
+#[derive(Debug, Clone, Copy, Default, Deserialize, Serialize)]
 pub enum InventoryMode {
     #[default]
-    Disabled = -1,
-    Manual = 0,
-    Automatic = 1,
+    #[serde(rename = "-1")]
+    Disabled,
+    #[serde(rename = "0")]
+    Manual,
+    #[serde(rename = "1")]
+    Automatic,
 }
 
 impl CreateHostRequest {

--- a/src/host/create.rs
+++ b/src/host/create.rs
@@ -1,7 +1,7 @@
 use super::model::{ZabbixHostInterface, ZabbixHostInventory, ZabbixHostTag};
 use crate::r#macro::create::CreateZabbixHostMacro;
 use crate::{hostgroup::model::ZabbixHostGroupId, template::model::ZabbixTemplateId};
-use serde::{Deserialize, Serialize, Serializer};
+use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use serde_with::skip_serializing_none;
 

--- a/src/host/create.rs
+++ b/src/host/create.rs
@@ -1,28 +1,21 @@
-use std::collections::HashMap;
-
-use serde::{Deserialize, Serialize};
-
-use crate::{
-    hostgroup::model::ZabbixHostGroupId, r#macro::model::ZabbixHostMacro,
-    template::model::ZabbixTemplateId,
-};
-
-use super::model::{ZabbixHostInterface, ZabbixHostTag};
+use super::model::{ZabbixHostInterface, ZabbixHostInventory, ZabbixHostTag};
+use crate::r#macro::create::CreateZabbixHostMacro;
+use crate::{hostgroup::model::ZabbixHostGroupId, template::model::ZabbixTemplateId};
+use serde::{Deserialize, Serialize, Serializer};
+use serde_repr::{Deserialize_repr, Serialize_repr};
+use serde_with::skip_serializing_none;
 
 const PSK: u8 = 2;
 const CERT: u8 = 4;
 
 #[derive(Serialize, Debug)]
+#[skip_serializing_none]
 pub struct TlsConfig {
     tls_connect: u8,
     tls_accept: u8,
-    #[serde(skip_serializing_if = "Option::is_none")]
     tls_psk_identity: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     tls_psk: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     tls_issuer: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     tls_subject: Option<String>,
 }
 
@@ -51,37 +44,158 @@ impl TlsConfig {
 }
 
 /// API: https://www.zabbix.com/documentation/6.0/en/manual/api/reference/host/create
-#[derive(Serialize, Debug)]
+#[derive(Serialize, Debug, Default)]
+#[skip_serializing_none]
 pub struct CreateHostRequest {
     pub host: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     pub groups: Vec<ZabbixHostGroupId>,
     pub interfaces: Vec<ZabbixHostInterface>,
     pub tags: Vec<ZabbixHostTag>,
     pub templates: Vec<ZabbixTemplateId>,
-    pub macros: Vec<ZabbixHostMacro>,
-    pub inventory_mode: u8,
-    pub inventory: HashMap<String, String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    pub macros: Vec<CreateZabbixHostMacro>,
+    pub inventory_mode: InventoryMode,
+    pub inventory: ZabbixHostInventory,
     #[serde(flatten)]
     pub tls_config: Option<TlsConfig>,
 }
 
-impl Default for CreateHostRequest {
-    fn default() -> CreateHostRequest {
-        CreateHostRequest {
-            host: "".to_string(),
-            name: None,
-            groups: Vec::new(),
-            interfaces: Vec::new(),
-            tags: Vec::new(),
-            templates: Vec::new(),
-            macros: Vec::new(),
-            inventory_mode: 0,
-            inventory: HashMap::new(),
-            tls_config: None,
+#[derive(Debug, Clone, Copy, Default, Deserialize_repr, Serialize_repr)]
+#[repr(i8)]
+pub enum InventoryMode {
+    #[default]
+    Disabled = -1,
+    Manual = 0,
+    Automatic = 1,
+}
+
+impl CreateHostRequest {
+    pub fn builder(host: impl ToString) -> CreateHostRequestBuilder {
+        CreateHostRequestBuilder::new(host)
+    }
+}
+
+pub struct CreateHostRequestBuilder {
+    inner: CreateHostRequest,
+}
+
+impl CreateHostRequestBuilder {
+    pub fn new(host: impl ToString) -> Self {
+        Self {
+            inner: CreateHostRequest {
+                host: host.to_string(),
+                ..Default::default()
+            },
         }
+    }
+
+    pub fn name(mut self, name: impl ToString) -> Self {
+        self.inner.name = Some(name.to_string());
+        self
+    }
+
+    pub fn group(mut self, group_id: impl ToString) -> Self {
+        self.inner.groups.push(ZabbixHostGroupId {
+            group_id: group_id.to_string(),
+        });
+        self
+    }
+
+    pub fn groups(mut self, groups: Vec<ZabbixHostGroupId>) -> Self {
+        self.inner.groups = groups;
+        self
+    }
+
+    pub fn interface(mut self, interface: ZabbixHostInterface) -> Self {
+        self.inner.interfaces.push(interface);
+        self
+    }
+
+    pub fn interfaces(mut self, interfaces: Vec<ZabbixHostInterface>) -> Self {
+        self.inner.interfaces = interfaces;
+        self
+    }
+
+    pub fn tag(mut self, tag: impl ToString, value: impl ToString) -> Self {
+        self.inner.tags.push(ZabbixHostTag {
+            tag: tag.to_string(),
+            value: value.to_string(),
+        });
+        self
+    }
+
+    pub fn tags(mut self, tags: Vec<ZabbixHostTag>) -> Self {
+        self.inner.tags = tags;
+        self
+    }
+
+    pub fn template(mut self, template_id: impl ToString) -> Self {
+        self.inner.templates.push(ZabbixTemplateId {
+            template_id: template_id.to_string(),
+        });
+        self
+    }
+
+    pub fn templates(mut self, templates: Vec<ZabbixTemplateId>) -> Self {
+        self.inner.templates = templates;
+        self
+    }
+
+    pub fn macro_entry(mut self, macro_entry: CreateZabbixHostMacro) -> Self {
+        self.inner.macros.push(macro_entry);
+        self
+    }
+
+    pub fn macros(mut self, macros: Vec<CreateZabbixHostMacro>) -> Self {
+        self.inner.macros = macros;
+        self
+    }
+
+    pub fn inventory_mode(mut self, mode: InventoryMode) -> Self {
+        self.inner.inventory_mode = mode;
+        self
+    }
+
+    pub fn inventory_disabled(mut self) -> Self {
+        self.inner.inventory_mode = InventoryMode::Disabled;
+        self
+    }
+
+    pub fn inventory_manual(mut self) -> Self {
+        self.inner.inventory_mode = InventoryMode::Manual;
+        self
+    }
+
+    pub fn inventory_automatic(mut self) -> Self {
+        self.inner.inventory_mode = InventoryMode::Automatic;
+        self
+    }
+
+    pub fn inventory(mut self, inventory: ZabbixHostInventory) -> Self {
+        self.inner.inventory = inventory;
+        self
+    }
+
+    pub fn tls_psk(mut self, psk_identity: impl ToString, psk: impl ToString) -> Self {
+        self.inner.tls_config = Some(TlsConfig::new_psk(
+            psk_identity.to_string(),
+            psk.to_string(),
+        ));
+        self
+    }
+
+    pub fn tls_cert(mut self, issuer: impl ToString, subject: impl ToString) -> Self {
+        self.inner.tls_config = Some(TlsConfig::new_cert(issuer.to_string(), subject.to_string()));
+        self
+    }
+
+    pub fn tls_config(mut self, tls_config: TlsConfig) -> Self {
+        self.inner.tls_config = Some(tls_config);
+        self
+    }
+
+    pub fn build(self) -> CreateHostRequest {
+        self.inner
     }
 }
 

--- a/src/host/model.rs
+++ b/src/host/model.rs
@@ -43,15 +43,454 @@ pub struct ZabbixHostTag {
 #[derive(Serialize, Deserialize, PartialEq, Clone, Debug)]
 pub struct ZabbixHostInterface {
     pub r#type: u8,
-
     pub main: u8,
-
     pub ip: String,
-
     pub dns: String,
-
     pub port: String,
-
     #[serde(rename = "useip")]
     pub use_ip: u8,
+}
+
+/// API Object: https://www.zabbix.com/documentation/6.0/en/manual/api/reference/host/object#host-inventory
+#[derive(Serialize, Deserialize, PartialEq, Clone, Debug, Default)]
+#[skip_serializing_none]
+pub struct ZabbixHostInventory {
+    #[serde(rename = "type")]
+    pub r#type: Option<String>,
+    pub type_full: Option<String>,
+    pub name: Option<String>,
+    pub alias: Option<String>,
+    pub os: Option<String>,
+    pub os_full: Option<String>,
+    pub os_short: Option<String>,
+    pub serialno_a: Option<String>,
+    pub serialno_b: Option<String>,
+    pub tag: Option<String>,
+    pub asset_tag: Option<String>,
+    pub macaddress_a: Option<String>,
+    pub macaddress_b: Option<String>,
+    pub hardware: Option<String>,
+    pub hardware_full: Option<String>,
+    pub software: Option<String>,
+    pub software_full: Option<String>,
+    pub software_app_a: Option<String>,
+    pub software_app_b: Option<String>,
+    pub software_app_c: Option<String>,
+    pub software_app_d: Option<String>,
+    pub software_app_e: Option<String>,
+    pub contact: Option<String>,
+    pub location: Option<String>,
+    pub location_lat: Option<String>,
+    pub location_lon: Option<String>,
+    pub notes: Option<String>,
+    pub chassis: Option<String>,
+    pub model: Option<String>,
+    pub hw_arch: Option<String>,
+    pub vendor: Option<String>,
+    pub contract_number: Option<String>,
+    pub installer_name: Option<String>,
+    pub deployment_status: Option<String>,
+    pub url_a: Option<String>,
+    pub url_b: Option<String>,
+    pub url_c: Option<String>,
+    pub host_networks: Option<String>,
+    pub host_netmask: Option<String>,
+    pub host_router: Option<String>,
+    pub oob_ip: Option<String>,
+    pub oob_netmask: Option<String>,
+    pub oob_router: Option<String>,
+    pub date_hw_purchase: Option<String>,
+    pub date_hw_install: Option<String>,
+    pub date_hw_expiry: Option<String>,
+    pub date_hw_decomm: Option<String>,
+    pub site_address_a: Option<String>,
+    pub site_address_b: Option<String>,
+    pub site_address_c: Option<String>,
+    pub site_city: Option<String>,
+    pub site_state: Option<String>,
+    pub site_country: Option<String>,
+    pub site_zip: Option<String>,
+    pub site_rack: Option<String>,
+    pub site_notes: Option<String>,
+    pub poc_1_name: Option<String>,
+    pub poc_1_email: Option<String>,
+    pub poc_1_phone_a: Option<String>,
+    pub poc_1_phone_b: Option<String>,
+    pub poc_1_cell: Option<String>,
+    pub poc_1_screen: Option<String>,
+    pub poc_1_notes: Option<String>,
+    pub poc_2_name: Option<String>,
+    pub poc_2_email: Option<String>,
+    pub poc_2_phone_a: Option<String>,
+    pub poc_2_phone_b: Option<String>,
+    pub poc_2_cell: Option<String>,
+    pub poc_2_screen: Option<String>,
+    pub poc_2_notes: Option<String>,
+}
+
+impl ZabbixHostInventory {
+    pub fn builder() -> ZabbixHostInventoryBuilder {
+        ZabbixHostInventoryBuilder::default()
+    }
+}
+
+#[derive(Default)]
+pub struct ZabbixHostInventoryBuilder {
+    inner: ZabbixHostInventory,
+}
+
+impl ZabbixHostInventoryBuilder {
+    pub fn r#type(mut self, value: impl ToString) -> Self {
+        self.inner.r#type = Some(value.to_string());
+        self
+    }
+
+    pub fn type_full(mut self, value: impl ToString) -> Self {
+        self.inner.type_full = Some(value.to_string());
+        self
+    }
+
+    pub fn name(mut self, value: impl ToString) -> Self {
+        self.inner.name = Some(value.to_string());
+        self
+    }
+
+    pub fn alias(mut self, value: impl ToString) -> Self {
+        self.inner.alias = Some(value.to_string());
+        self
+    }
+
+    pub fn os(mut self, value: impl ToString) -> Self {
+        self.inner.os = Some(value.to_string());
+        self
+    }
+
+    pub fn os_full(mut self, value: impl ToString) -> Self {
+        self.inner.os_full = Some(value.to_string());
+        self
+    }
+
+    pub fn os_short(mut self, value: impl ToString) -> Self {
+        self.inner.os_short = Some(value.to_string());
+        self
+    }
+
+    pub fn serialno_a(mut self, value: impl ToString) -> Self {
+        self.inner.serialno_a = Some(value.to_string());
+        self
+    }
+
+    pub fn serialno_b(mut self, value: impl ToString) -> Self {
+        self.inner.serialno_b = Some(value.to_string());
+        self
+    }
+
+    pub fn tag(mut self, value: impl ToString) -> Self {
+        self.inner.tag = Some(value.to_string());
+        self
+    }
+
+    pub fn asset_tag(mut self, value: impl ToString) -> Self {
+        self.inner.asset_tag = Some(value.to_string());
+        self
+    }
+
+    pub fn macaddress_a(mut self, value: impl ToString) -> Self {
+        self.inner.macaddress_a = Some(value.to_string());
+        self
+    }
+
+    pub fn macaddress_b(mut self, value: impl ToString) -> Self {
+        self.inner.macaddress_b = Some(value.to_string());
+        self
+    }
+
+    pub fn hardware(mut self, value: impl ToString) -> Self {
+        self.inner.hardware = Some(value.to_string());
+        self
+    }
+
+    pub fn hardware_full(mut self, value: impl ToString) -> Self {
+        self.inner.hardware_full = Some(value.to_string());
+        self
+    }
+
+    pub fn software(mut self, value: impl ToString) -> Self {
+        self.inner.software = Some(value.to_string());
+        self
+    }
+
+    pub fn software_full(mut self, value: impl ToString) -> Self {
+        self.inner.software_full = Some(value.to_string());
+        self
+    }
+
+    pub fn software_app_a(mut self, value: impl ToString) -> Self {
+        self.inner.software_app_a = Some(value.to_string());
+        self
+    }
+
+    pub fn software_app_b(mut self, value: impl ToString) -> Self {
+        self.inner.software_app_b = Some(value.to_string());
+        self
+    }
+
+    pub fn software_app_c(mut self, value: impl ToString) -> Self {
+        self.inner.software_app_c = Some(value.to_string());
+        self
+    }
+
+    pub fn software_app_d(mut self, value: impl ToString) -> Self {
+        self.inner.software_app_d = Some(value.to_string());
+        self
+    }
+
+    pub fn software_app_e(mut self, value: impl ToString) -> Self {
+        self.inner.software_app_e = Some(value.to_string());
+        self
+    }
+
+    pub fn contact(mut self, value: impl ToString) -> Self {
+        self.inner.contact = Some(value.to_string());
+        self
+    }
+
+    pub fn location(mut self, value: impl ToString) -> Self {
+        self.inner.location = Some(value.to_string());
+        self
+    }
+
+    pub fn location_lat(mut self, value: impl ToString) -> Self {
+        self.inner.location_lat = Some(value.to_string());
+        self
+    }
+
+    pub fn location_lon(mut self, value: impl ToString) -> Self {
+        self.inner.location_lon = Some(value.to_string());
+        self
+    }
+
+    pub fn notes(mut self, value: impl ToString) -> Self {
+        self.inner.notes = Some(value.to_string());
+        self
+    }
+
+    pub fn chassis(mut self, value: impl ToString) -> Self {
+        self.inner.chassis = Some(value.to_string());
+        self
+    }
+
+    pub fn model(mut self, value: impl ToString) -> Self {
+        self.inner.model = Some(value.to_string());
+        self
+    }
+
+    pub fn hw_arch(mut self, value: impl ToString) -> Self {
+        self.inner.hw_arch = Some(value.to_string());
+        self
+    }
+
+    pub fn vendor(mut self, value: impl ToString) -> Self {
+        self.inner.vendor = Some(value.to_string());
+        self
+    }
+
+    pub fn contract_number(mut self, value: impl ToString) -> Self {
+        self.inner.contract_number = Some(value.to_string());
+        self
+    }
+
+    pub fn installer_name(mut self, value: impl ToString) -> Self {
+        self.inner.installer_name = Some(value.to_string());
+        self
+    }
+
+    pub fn deployment_status(mut self, value: impl ToString) -> Self {
+        self.inner.deployment_status = Some(value.to_string());
+        self
+    }
+
+    pub fn url_a(mut self, value: impl ToString) -> Self {
+        self.inner.url_a = Some(value.to_string());
+        self
+    }
+
+    pub fn url_b(mut self, value: impl ToString) -> Self {
+        self.inner.url_b = Some(value.to_string());
+        self
+    }
+
+    pub fn url_c(mut self, value: impl ToString) -> Self {
+        self.inner.url_c = Some(value.to_string());
+        self
+    }
+
+    pub fn host_networks(mut self, value: impl ToString) -> Self {
+        self.inner.host_networks = Some(value.to_string());
+        self
+    }
+
+    pub fn host_netmask(mut self, value: impl ToString) -> Self {
+        self.inner.host_netmask = Some(value.to_string());
+        self
+    }
+
+    pub fn host_router(mut self, value: impl ToString) -> Self {
+        self.inner.host_router = Some(value.to_string());
+        self
+    }
+
+    pub fn oob_ip(mut self, value: impl ToString) -> Self {
+        self.inner.oob_ip = Some(value.to_string());
+        self
+    }
+
+    pub fn oob_netmask(mut self, value: impl ToString) -> Self {
+        self.inner.oob_netmask = Some(value.to_string());
+        self
+    }
+
+    pub fn oob_router(mut self, value: impl ToString) -> Self {
+        self.inner.oob_router = Some(value.to_string());
+        self
+    }
+
+    pub fn date_hw_purchase(mut self, value: impl ToString) -> Self {
+        self.inner.date_hw_purchase = Some(value.to_string());
+        self
+    }
+
+    pub fn date_hw_install(mut self, value: impl ToString) -> Self {
+        self.inner.date_hw_install = Some(value.to_string());
+        self
+    }
+
+    pub fn date_hw_expiry(mut self, value: impl ToString) -> Self {
+        self.inner.date_hw_expiry = Some(value.to_string());
+        self
+    }
+
+    pub fn date_hw_decomm(mut self, value: impl ToString) -> Self {
+        self.inner.date_hw_decomm = Some(value.to_string());
+        self
+    }
+
+    pub fn site_address_a(mut self, value: impl ToString) -> Self {
+        self.inner.site_address_a = Some(value.to_string());
+        self
+    }
+
+    pub fn site_address_b(mut self, value: impl ToString) -> Self {
+        self.inner.site_address_b = Some(value.to_string());
+        self
+    }
+
+    pub fn site_address_c(mut self, value: impl ToString) -> Self {
+        self.inner.site_address_c = Some(value.to_string());
+        self
+    }
+
+    pub fn site_city(mut self, value: impl ToString) -> Self {
+        self.inner.site_city = Some(value.to_string());
+        self
+    }
+
+    pub fn site_state(mut self, value: impl ToString) -> Self {
+        self.inner.site_state = Some(value.to_string());
+        self
+    }
+
+    pub fn site_country(mut self, value: impl ToString) -> Self {
+        self.inner.site_country = Some(value.to_string());
+        self
+    }
+
+    pub fn site_zip(mut self, value: impl ToString) -> Self {
+        self.inner.site_zip = Some(value.to_string());
+        self
+    }
+
+    pub fn site_rack(mut self, value: impl ToString) -> Self {
+        self.inner.site_rack = Some(value.to_string());
+        self
+    }
+
+    pub fn site_notes(mut self, value: impl ToString) -> Self {
+        self.inner.site_notes = Some(value.to_string());
+        self
+    }
+
+    pub fn poc_1_name(mut self, value: impl ToString) -> Self {
+        self.inner.poc_1_name = Some(value.to_string());
+        self
+    }
+
+    pub fn poc_1_email(mut self, value: impl ToString) -> Self {
+        self.inner.poc_1_email = Some(value.to_string());
+        self
+    }
+
+    pub fn poc_1_phone_a(mut self, value: impl ToString) -> Self {
+        self.inner.poc_1_phone_a = Some(value.to_string());
+        self
+    }
+
+    pub fn poc_1_phone_b(mut self, value: impl ToString) -> Self {
+        self.inner.poc_1_phone_b = Some(value.to_string());
+        self
+    }
+
+    pub fn poc_1_cell(mut self, value: impl ToString) -> Self {
+        self.inner.poc_1_cell = Some(value.to_string());
+        self
+    }
+
+    pub fn poc_1_screen(mut self, value: impl ToString) -> Self {
+        self.inner.poc_1_screen = Some(value.to_string());
+        self
+    }
+
+    pub fn poc_1_notes(mut self, value: impl ToString) -> Self {
+        self.inner.poc_1_notes = Some(value.to_string());
+        self
+    }
+
+    pub fn poc_2_name(mut self, value: impl ToString) -> Self {
+        self.inner.poc_2_name = Some(value.to_string());
+        self
+    }
+
+    pub fn poc_2_email(mut self, value: impl ToString) -> Self {
+        self.inner.poc_2_email = Some(value.to_string());
+        self
+    }
+
+    pub fn poc_2_phone_a(mut self, value: impl ToString) -> Self {
+        self.inner.poc_2_phone_a = Some(value.to_string());
+        self
+    }
+
+    pub fn poc_2_phone_b(mut self, value: impl ToString) -> Self {
+        self.inner.poc_2_phone_b = Some(value.to_string());
+        self
+    }
+
+    pub fn poc_2_cell(mut self, value: impl ToString) -> Self {
+        self.inner.poc_2_cell = Some(value.to_string());
+        self
+    }
+
+    pub fn poc_2_screen(mut self, value: impl ToString) -> Self {
+        self.inner.poc_2_screen = Some(value.to_string());
+        self
+    }
+
+    pub fn poc_2_notes(mut self, value: impl ToString) -> Self {
+        self.inner.poc_2_notes = Some(value.to_string());
+        self
+    }
+
+    pub fn build(self) -> ZabbixHostInventory {
+        self.inner
+    }
 }

--- a/src/host/model.rs
+++ b/src/host/model.rs
@@ -1,36 +1,14 @@
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
 use std::cmp::PartialEq;
 use std::str::FromStr;
+use serde_repr::{Deserialize_repr, Serialize_repr};
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Deserialize_repr, Serialize_repr)]
+#[repr(u8)]
 pub enum HostStatus {
-    Enabled,
-    Disabled,
-}
-
-impl Serialize for HostStatus {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let value = match self {
-            HostStatus::Enabled => "0",
-            HostStatus::Disabled => "1",
-        };
-
-        serializer.serialize_str(value)
-    }
-}
-
-impl<'de> Deserialize<'de> for HostStatus {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let value = String::deserialize(deserializer)?;
-
-        HostStatus::from_str(&value).map_err(|_| serde::de::Error::custom(format!("Invalid HostStatus value: {}", value)))
-    }
+    Enabled = 0,
+    Disabled = 1,
 }
 
 impl FromStr for HostStatus {

--- a/src/host/model.rs
+++ b/src/host/model.rs
@@ -2,13 +2,13 @@ use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 use std::cmp::PartialEq;
 use std::str::FromStr;
-use serde_repr::{Deserialize_repr, Serialize_repr};
 
-#[derive(Clone, Debug, PartialEq, Deserialize_repr, Serialize_repr)]
-#[repr(u8)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub enum HostStatus {
-    Enabled = 0,
-    Disabled = 1,
+    #[serde(rename = "0")]
+    Enabled,
+    #[serde(rename = "1")]
+    Disabled,
 }
 
 impl FromStr for HostStatus {
@@ -52,8 +52,8 @@ pub struct ZabbixHostInterface {
 }
 
 /// API Object: https://www.zabbix.com/documentation/6.0/en/manual/api/reference/host/object#host-inventory
-#[derive(Serialize, Deserialize, PartialEq, Clone, Debug, Default)]
 #[skip_serializing_none]
+#[derive(Serialize, Deserialize, PartialEq, Clone, Debug, Default)]
 pub struct ZabbixHostInventory {
     #[serde(rename = "type")]
     pub r#type: Option<String>,

--- a/src/host/update.rs
+++ b/src/host/update.rs
@@ -1,5 +1,5 @@
-use serde::{Deserialize, Serialize};
 use crate::host::model::HostStatus;
+use serde::{Deserialize, Serialize};
 
 /// Represents a host update request in Zabbix API
 #[derive(Debug, Serialize)]

--- a/src/item/get.rs
+++ b/src/item/get.rs
@@ -1,7 +1,7 @@
 use serde::Serialize;
 
 /// API: https://www.zabbix.com/documentation/6.0/en/manual/api/reference/item/get
-#[derive(Serialize,Debug)]
+#[derive(Serialize, Debug)]
 pub struct GetItemsRequestById<R> {
     pub output: String,
     pub with_triggers: bool,
@@ -9,20 +9,20 @@ pub struct GetItemsRequestById<R> {
     pub host_ids: String,
     pub search: R,
     #[serde(rename = "sortfield")]
-    pub sort_field: String
+    pub sort_field: String,
 }
 
 /// API: https://www.zabbix.com/documentation/6.0/en/manual/api/reference/item/get
-#[derive(Serialize,Debug)]
+#[derive(Serialize, Debug)]
 pub struct GetItemsRequestByKey<R> {
     pub output: String,
     pub with_triggers: bool,
     pub search: R,
     #[serde(rename = "sortfield")]
-    pub sort_field: String
+    pub sort_field: String,
 }
 
-#[derive(Serialize,Debug)]
+#[derive(Serialize, Debug)]
 pub struct SearchByKey {
     pub key_: String,
 }

--- a/src/macro/create.rs
+++ b/src/macro/create.rs
@@ -2,8 +2,8 @@ use crate::r#macro::macrotype::MacroType;
 use serde::Serialize;
 use serde_with::skip_serializing_none;
 
-#[derive(Serialize, Debug, Default)]
 #[skip_serializing_none]
+#[derive(Serialize, Debug, Default)]
 pub struct CreateZabbixHostMacro {
     #[serde(rename = "macro")]
     pub macro_name: String,

--- a/src/macro/create.rs
+++ b/src/macro/create.rs
@@ -1,0 +1,63 @@
+use crate::r#macro::macrotype::MacroType;
+use serde::Serialize;
+use serde_with::skip_serializing_none;
+
+#[derive(Serialize, Debug, Default)]
+#[skip_serializing_none]
+pub struct CreateZabbixHostMacro {
+    #[serde(rename = "macro")]
+    pub macro_name: String,
+    #[serde(rename = "value")]
+    pub macro_value: String,
+    pub description: Option<String>,
+    #[serde(rename = "type")]
+    pub macro_type: Option<MacroType>,
+}
+
+impl CreateZabbixHostMacro {
+    pub fn builder() -> CreateZabbixHostMacroBuilder {
+        CreateZabbixHostMacroBuilder {
+            inner: CreateZabbixHostMacro::default(),
+        }
+    }
+}
+
+pub struct CreateZabbixHostMacroBuilder {
+    inner: CreateZabbixHostMacro,
+}
+
+impl CreateZabbixHostMacroBuilder {
+    pub fn macro_name(mut self, value: impl ToString) -> Self {
+        self.inner.macro_name = value.to_string();
+        self
+    }
+
+    pub fn value(mut self, value: impl ToString) -> Self {
+        self.inner.macro_value = value.to_string();
+        self
+    }
+
+    pub fn description(mut self, value: impl ToString) -> Self {
+        self.inner.description = Some(value.to_string());
+        self
+    }
+
+    pub fn text(mut self) -> Self {
+        self.inner.macro_type = Some(MacroType::Text);
+        self
+    }
+
+    pub fn secret(mut self) -> Self {
+        self.inner.macro_type = Some(MacroType::Secret);
+        self
+    }
+
+    pub fn vault(mut self) -> Self {
+        self.inner.macro_type = Some(MacroType::Vault);
+        self
+    }
+
+    pub fn build(self) -> CreateZabbixHostMacro {
+        self.inner
+    }
+}

--- a/src/macro/macrotype.rs
+++ b/src/macro/macrotype.rs
@@ -1,10 +1,12 @@
-use serde_repr::{Deserialize_repr, Serialize_repr};
+use serde::{Deserialize, Serialize};
 
-#[derive(Default, Debug, Deserialize_repr, Serialize_repr)]
-#[repr(u8)]
+#[derive(Default, Debug, Deserialize, Serialize)]
 pub enum MacroType {
     #[default]
-    Text = 0,
-    Secret = 1,
-    Vault = 2,
+    #[serde(rename = "0")]
+    Text,
+    #[serde(rename = "1")]
+    Secret,
+    #[serde(rename = "2")]
+    Vault,
 }

--- a/src/macro/macrotype.rs
+++ b/src/macro/macrotype.rs
@@ -1,0 +1,10 @@
+use serde_repr::{Deserialize_repr, Serialize_repr};
+
+#[derive(Default, Debug, Deserialize_repr, Serialize_repr)]
+#[repr(u8)]
+pub enum MacroType {
+    #[default]
+    Text = 0,
+    Secret = 1,
+    Vault = 2,
+}

--- a/src/macro/mod.rs
+++ b/src/macro/mod.rs
@@ -1,1 +1,3 @@
+pub mod create;
 pub mod model;
+pub mod macrotype;

--- a/src/macro/model.rs
+++ b/src/macro/model.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use crate::r#macro::macrotype::MacroType;
 
 /// API Object: https://www.zabbix.com/documentation/6.0/en/manual/api/reference/usermacro/object
 #[derive(Deserialize, Debug)]
@@ -20,6 +21,6 @@ pub struct ZabbixHostMacro {
     pub host_id: String,
     pub r#macro: String,
     pub value: String,
-    pub r#type: u8,
+    pub r#type: MacroType,
     pub description: String,
 }

--- a/src/tests/builder.rs
+++ b/src/tests/builder.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::error::Error;
 
 use crate::client::client::{ZabbixApiClient, ZabbixApiClientImpl};
-use crate::host::create::TlsConfig;
+use crate::host::create::{InventoryMode, TlsConfig};
 use crate::host::update::UpdateHostRequest;
 use crate::hostgroup::create::CreateHostGroupRequest;
 use crate::hostgroup::model::ZabbixHostGroupId;
@@ -11,7 +11,7 @@ use log::{debug, error};
 use reqwest::blocking::Client;
 
 use crate::host::create::CreateHostRequest;
-use crate::host::model::ZabbixHostInterface;
+use crate::host::model::{ZabbixHostInterface, ZabbixHostInventory};
 use crate::item::create::CreateItemRequest;
 use crate::tests::integration::{get_integration_tests_config, IntegrationTestsConfig};
 use crate::trigger::create::CreateTriggerRequest;
@@ -101,8 +101,8 @@ impl TestEnvBuilder {
             tags: vec![],
             templates: vec![],
             macros: vec![],
-            inventory_mode: 0,
-            inventory: HashMap::new(),
+            inventory_mode: InventoryMode::Manual,
+            inventory: ZabbixHostInventory::default(),
             tls_config: tls_config,
             ..Default::default()
         };

--- a/src/tests/builder.rs
+++ b/src/tests/builder.rs
@@ -97,7 +97,14 @@ impl TestEnvBuilder {
             groups: vec![ZabbixHostGroupId {
                 group_id: self.latest_host_group_id.to_string(),
             }],
-            interfaces: vec![ZabbixHostInterface { r#type: 1, main: 1, use_ip: 1, ip: "127.0.0.1".to_string(), dns: "".to_string(), port: "10050".to_string() }],
+            interfaces: vec![ZabbixHostInterface {
+                r#type: 1,
+                main: 1,
+                use_ip: 1,
+                ip: "127.0.0.1".to_string(),
+                dns: "".to_string(),
+                port: "10050".to_string(),
+            }],
             tags: vec![],
             templates: vec![],
             macros: vec![],
@@ -128,9 +135,12 @@ impl TestEnvBuilder {
 
         match &self.client.update_host(&self.session, &update_host) {
             Ok(_) => {
-                match &self.client.get_hosts(&self.session, &GetHostsByIdsRequest {
-                    hostids: vec![update_host.hostid.clone()],
-                }) {
+                match &self.client.get_hosts(
+                    &self.session,
+                    &GetHostsByIdsRequest {
+                        hostids: vec![update_host.hostid.clone()],
+                    },
+                ) {
                     Ok(hosts) => {
                         if hosts.is_empty() {
                             error!("host update error: {}", "host not found");
@@ -139,7 +149,10 @@ impl TestEnvBuilder {
 
                         let host = hosts.first().unwrap();
 
-                        debug!("host: {:?}, update_host: {:?}", host.status, update_host.status);
+                        debug!(
+                            "host: {:?}, update_host: {:?}",
+                            host.status, update_host.status
+                        );
                         if host.status != update_host.status {
                             error!("host update error: {}", "host status not updated");
                             panic!("host status not updated");

--- a/src/tests/integration.rs
+++ b/src/tests/integration.rs
@@ -5,9 +5,9 @@ const ENV_ZABBIX_API_USER: &str = "ZABBIX_API_USER";
 const ENV_ZABBIX_API_PASSWORD: &str = "ZABBIX_API_PASSWORD";
 
 pub fn are_integration_tests_enabled() -> bool {
-    let result = env::var(ENV_ZABBIX_API_URL).is_ok() &&
-        env::var(ENV_ZABBIX_API_USER).is_ok() &&
-        env::var(ENV_ZABBIX_API_PASSWORD).is_ok();
+    let result = env::var(ENV_ZABBIX_API_URL).is_ok()
+        && env::var(ENV_ZABBIX_API_USER).is_ok()
+        && env::var(ENV_ZABBIX_API_PASSWORD).is_ok();
 
     if !result {
         println!("/!\\ integration tests are disabled /!\\")
@@ -19,13 +19,13 @@ pub fn are_integration_tests_enabled() -> bool {
 pub struct IntegrationTestsConfig {
     pub zabbix_api_url: String,
     pub zabbix_api_user: String,
-    pub zabbix_api_password: String
+    pub zabbix_api_password: String,
 }
 
 pub fn get_integration_tests_config() -> IntegrationTestsConfig {
     IntegrationTestsConfig {
         zabbix_api_url: env::var(ENV_ZABBIX_API_URL).unwrap(),
         zabbix_api_user: env::var(ENV_ZABBIX_API_USER).unwrap(),
-        zabbix_api_password: env::var(ENV_ZABBIX_API_PASSWORD).unwrap()
+        zabbix_api_password: env::var(ENV_ZABBIX_API_PASSWORD).unwrap(),
     }
 }

--- a/src/tests/strings.rs
+++ b/src/tests/strings.rs
@@ -1,7 +1,11 @@
 use fake::{Fake, StringFaker};
 
 pub fn get_random_string() -> String {
-    StringFaker::with(Vec::from("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"), 12..32).fake()
+    StringFaker::with(
+        Vec::from("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"),
+        12..32,
+    )
+    .fake()
 }
 
 /// Generates a random 32-character hexadecimal string (16 bytes)

--- a/src/trigger/create.rs
+++ b/src/trigger/create.rs
@@ -3,8 +3,8 @@ use serde_with::skip_serializing_none;
 
 use super::model::ZabbixTriggerTag;
 
-#[derive(Serialize, Debug, Clone)]
 #[skip_serializing_none]
+#[derive(Serialize, Debug, Clone)]
 pub struct CreateTriggerRequest {
     pub description: String,
     pub expression: String,

--- a/src/trigger/create.rs
+++ b/src/trigger/create.rs
@@ -1,25 +1,18 @@
 use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
 
 use super::model::ZabbixTriggerTag;
 
 #[derive(Serialize, Debug, Clone)]
+#[skip_serializing_none]
 pub struct CreateTriggerRequest {
     pub description: String,
     pub expression: String,
     pub priority: u8,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub recovery_mode: Option<u8>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub recovery_expression: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub event_name: Option<String>,
-
     pub dependencies: Vec<ZabbixTriggerDependency>,
     pub tags: Vec<ZabbixTriggerTag>,
 }

--- a/src/trigger/get.rs
+++ b/src/trigger/get.rs
@@ -3,30 +3,30 @@ use serde::Serialize;
 use crate::ZABBIX_EXTEND_PROPERTY_VALUE;
 
 /// API: https://www.zabbix.com/documentation/6.0/en/manual/api/reference/trigger/get
-#[derive(Serialize,Debug)]
+#[derive(Serialize, Debug)]
 pub struct GetTriggerByIdRequest {
     /// Trigger ID
     #[serde(rename = "triggerids")]
     pub trigger_ids: String,
     pub output: String,
     #[serde(rename = "selectFunctions")]
-    pub select_functions: String
+    pub select_functions: String,
 }
 
 /// API: https://www.zabbix.com/documentation/6.0/en/manual/api/reference/trigger/get
-#[derive(Serialize,Debug)]
+#[derive(Serialize, Debug)]
 pub struct GetTriggerByDescriptionRequest {
     pub search: TriggerNameSearch,
     pub output: String,
     #[serde(rename = "selectFunctions")]
-    pub select_functions: String
+    pub select_functions: String,
 }
 
 impl GetTriggerByDescriptionRequest {
     pub fn new(description: &str) -> GetTriggerByDescriptionRequest {
         GetTriggerByDescriptionRequest {
             search: TriggerNameSearch {
-                description: description.to_string()
+                description: description.to_string(),
             },
             output: ZABBIX_EXTEND_PROPERTY_VALUE.to_string(),
             select_functions: ZABBIX_EXTEND_PROPERTY_VALUE.to_string(),
@@ -34,7 +34,7 @@ impl GetTriggerByDescriptionRequest {
     }
 }
 
-#[derive(Serialize,Debug)]
+#[derive(Serialize, Debug)]
 pub struct TriggerNameSearch {
     pub description: String,
 }

--- a/src/user/create.rs
+++ b/src/user/create.rs
@@ -6,8 +6,8 @@ pub struct UserGroupId {
     pub usrgrpid: String,
 }
 
-#[derive(Serialize, Debug, Clone, Default)]
 #[skip_serializing_none]
+#[derive(Serialize, Debug, Clone, Default)]
 pub struct UserMedia {
     pub mediatypeid: String,
     pub sendto: String,
@@ -16,8 +16,8 @@ pub struct UserMedia {
     pub period: Option<String>,
 }
 
-#[derive(Serialize, Debug, Clone, Default)]
 #[skip_serializing_none]
+#[derive(Serialize, Debug, Clone, Default)]
 pub struct CreateUserRequest {
     pub username: String,
     pub passwd: String,

--- a/src/user/create.rs
+++ b/src/user/create.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
 
 #[derive(Serialize, Debug, Clone)]
 pub struct UserGroupId {
@@ -6,41 +7,33 @@ pub struct UserGroupId {
 }
 
 #[derive(Serialize, Debug, Clone, Default)]
+#[skip_serializing_none]
 pub struct UserMedia {
     pub mediatypeid: String,
     pub sendto: String,
     pub active: i32,
     pub severity: i32,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub period: Option<String>,
 }
 
 #[derive(Serialize, Debug, Clone, Default)]
+#[skip_serializing_none]
 pub struct CreateUserRequest {
     pub username: String,
     pub passwd: String,
     pub roleid: String,
     pub usrgrps: Vec<UserGroupId>,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub surname: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub autologin: Option<i32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub autologout: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub lang: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub refresh: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub theme: Option<String>,
-    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "type")]
     pub user_type: Option<i32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub user_medias: Option<Vec<UserMedia>>,
 }
 

--- a/src/user/mod.rs
+++ b/src/user/mod.rs
@@ -1,2 +1,2 @@
-pub mod model;
 pub mod create;
+pub mod model;

--- a/src/user/model.rs
+++ b/src/user/model.rs
@@ -1,19 +1,18 @@
 use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[skip_serializing_none]
 pub struct ZabbixUser {
     #[serde(rename = "userid")]
     pub user_id: String,
     #[serde(alias = "username")]
     pub alias: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub surname: Option<String>,
-    #[serde(rename = "roleid", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "roleid")]
     pub role_id: Option<String>,
-    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "type")]
     pub user_type: Option<i32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
 }

--- a/src/user/model.rs
+++ b/src/user/model.rs
@@ -1,8 +1,8 @@
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
-#[derive(Serialize, Deserialize, Debug, Clone, Default)]
 #[skip_serializing_none]
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct ZabbixUser {
     #[serde(rename = "userid")]
     pub user_id: String,

--- a/src/usergroup/get.rs
+++ b/src/usergroup/get.rs
@@ -1,25 +1,22 @@
 use serde::Serialize;
+use serde_with::skip_serializing_none;
 
 #[derive(Serialize, Debug, Default)]
+#[skip_serializing_none]
 pub struct GetUserGroupsRequest<F: Serialize> {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub output: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub filter: Option<F>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub usrgrpids: Option<Vec<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub userids: Option<Vec<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<i32>,
-    #[serde(skip_serializing_if = "Option::is_none", rename = "selectUsers")]
+    #[serde(rename = "selectUsers")]
     pub select_users: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", rename = "selectRights")]
+    #[serde(rename = "selectRights")]
     pub select_rights: Option<String>,
 }
 
 #[derive(Serialize, Debug, Default)]
+#[skip_serializing_none]
 pub struct UserGroupFilter {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<Vec<String>>,
 }

--- a/src/usergroup/get.rs
+++ b/src/usergroup/get.rs
@@ -1,8 +1,8 @@
 use serde::Serialize;
 use serde_with::skip_serializing_none;
 
-#[derive(Serialize, Debug, Default)]
 #[skip_serializing_none]
+#[derive(Serialize, Debug, Default)]
 pub struct GetUserGroupsRequest<F: Serialize> {
     pub output: Option<String>,
     pub filter: Option<F>,
@@ -15,8 +15,8 @@ pub struct GetUserGroupsRequest<F: Serialize> {
     pub select_rights: Option<String>,
 }
 
-#[derive(Serialize, Debug, Default)]
 #[skip_serializing_none]
+#[derive(Serialize, Debug, Default)]
 pub struct UserGroupFilter {
     pub name: Option<Vec<String>>,
 }

--- a/src/usergroup/mod.rs
+++ b/src/usergroup/mod.rs
@@ -1,2 +1,2 @@
-pub mod model;
 pub mod get;
+pub mod model;

--- a/src/usergroup/model.rs
+++ b/src/usergroup/model.rs
@@ -16,8 +16,8 @@ pub struct UserGroupPermission {
     pub permission: i32,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
 #[skip_serializing_none]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ZabbixUserGroup {
     #[serde(rename = "usrgrpid")]
     pub usrgrp_id: String,
@@ -51,8 +51,8 @@ pub struct UserGroupUser {
 
 /// Parameters for the `usergroup.create` API method.
 /// See: https://www.zabbix.com/documentation/current/en/manual/api/reference/usergroup/create
-#[derive(Serialize, Deserialize, Debug, Clone, Default)]
 #[skip_serializing_none]
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct CreateUserGroupRequest {
     /// Name of the user group.
     pub name: String,
@@ -60,7 +60,7 @@ pub struct CreateUserGroupRequest {
     /// (optional) Whether debug mode is enabled or disabled.
     /// 0 - (default) disabled;
     /// 1 - enabled.
-    pub debug_mode: Option<i32>,
+    pub debug_mode: i32,
 
     /// (optional) Frontend authentication method of the users in the group.
     /// 0 - (default) use the system default authentication method;

--- a/src/usergroup/model.rs
+++ b/src/usergroup/model.rs
@@ -1,5 +1,6 @@
-use serde::{Deserialize, Serialize};
 use crate::user::model::ZabbixUser;
+use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
 
 /// Represents the permissions for a host group or template group within a user group.
 /// Corresponds to the "Permission" object in Zabbix API documentation.
@@ -16,19 +17,15 @@ pub struct UserGroupPermission {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[skip_serializing_none]
 pub struct ZabbixUserGroup {
     #[serde(rename = "usrgrpid")]
     pub usrgrp_id: String,
     pub name: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub gui_access: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub users_status: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub debug_mode: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub users: Option<Vec<ZabbixUser>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub rights: Option<Vec<UserGroupPermission>>,
 }
 
@@ -55,6 +52,7 @@ pub struct UserGroupUser {
 /// Parameters for the `usergroup.create` API method.
 /// See: https://www.zabbix.com/documentation/current/en/manual/api/reference/usergroup/create
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[skip_serializing_none]
 pub struct CreateUserGroupRequest {
     /// Name of the user group.
     pub name: String,
@@ -62,7 +60,6 @@ pub struct CreateUserGroupRequest {
     /// (optional) Whether debug mode is enabled or disabled.
     /// 0 - (default) disabled;
     /// 1 - enabled.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub debug_mode: Option<i32>,
 
     /// (optional) Frontend authentication method of the users in the group.
@@ -70,29 +67,23 @@ pub struct CreateUserGroupRequest {
     /// 1 - use internal authentication;
     /// 2 - use LDAP authentication;
     /// 3 - disable access to the frontend.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub gui_access: Option<i32>,
 
     /// (optional) Whether the user group is enabled or disabled.
     /// 0 - (default) enabled;
     /// 1 - disabled.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub users_status: Option<i32>,
 
     /// (optional) Host group permissions to assign to the user group.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub hostgroup_rights: Option<Vec<UserGroupPermission>>,
 
     /// (optional) Template group permissions to assign to the user group.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub templategroup_rights: Option<Vec<UserGroupPermission>>,
 
     /// (optional) Tag-based permissions to assign to the user group.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub tag_filters: Option<Vec<UserGroupTagFilter>>,
 
     /// (optional) Users to add to the user group.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub users: Option<Vec<UserGroupUser>>,
 }
 

--- a/src/webscenario/get.rs
+++ b/src/webscenario/get.rs
@@ -3,7 +3,7 @@ use serde::Serialize;
 use crate::ZABBIX_EXTEND_PROPERTY_VALUE;
 
 /// API: https://www.zabbix.com/documentation/6.0/en/manual/api/reference/httptest/get
-#[derive(Serialize,Debug)]
+#[derive(Serialize, Debug)]
 pub struct GetWebScenarioByIdRequest {
     pub output: String,
 
@@ -15,7 +15,7 @@ pub struct GetWebScenarioByIdRequest {
 }
 
 /// API: https://www.zabbix.com/documentation/6.0/en/manual/api/reference/httptest/get
-#[derive(Serialize,Debug)]
+#[derive(Serialize, Debug)]
 pub struct GetWebScenarioByNameRequest {
     pub output: String,
 
@@ -37,7 +37,7 @@ impl GetWebScenarioByNameRequest {
     }
 }
 
-#[derive(Serialize,Debug)]
+#[derive(Serialize, Debug)]
 pub struct WebScenarioNameFilter {
-    pub name: String
+    pub name: String,
 }


### PR DESCRIPTION
**1. Host Inventory as a dedicated structure**
- - [ZabbixHostInventory](./src/host/model.rs) — based on https://www.zabbix.com/documentation/6.0/en/manual/api/reference/host/object#host-inventory

**2. Builder Patterns** — Added builders for:
- [CreateHostRequest](./src/host/create.rs:47:0-59:1) — chainable host creation with groups, interfaces, tags, templates, macros, TLS config
- [ZabbixHostInventory](./src/host/model.rs:56:0-128:1) — 70+ optional inventory fields
- [CreateZabbixHostMacro](./src/macro/create.rs:6:0-11:36) — macro creation with type helpers

**3. Type-Safe Enums** — Replaced raw integers with enums:
- `InventoryMode` (Disabled/Manual/Automatic)
- `MacroType` (Text/Secret/Vault)
- `HostStatus` (Enabled/Disabled)

---

### Why

| Issue | Solution |
|-------|----------|
| Structs with many optional fields are tedious to construct | Builder pattern with sensible defaults |
| Magic numbers (`inventory_mode: 0`) could be unclear | Type-safe enums with descriptive variants |
|Many attribute #[serde(skip_serializing_if="Option::is_none")] is tedious to write|#[skip_serializing_none]|

Please let me know if the commit naming, ordering or structure in not complying with your vision.